### PR TITLE
Allow skipping non Algolia entities in commands

### DIFF
--- a/Command/ReindexCommand.php
+++ b/Command/ReindexCommand.php
@@ -2,6 +2,7 @@
 
 namespace Algolia\AlgoliaSearchBundle\Command;
 
+use Algolia\AlgoliaSearchBundle\Exception\NotAnAlgoliaEntity;
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -66,7 +67,11 @@ class ReindexCommand extends AlgoliaCommand
 
         $nIndexed = 0;
         foreach ($toReindex as $className) {
-            $nIndexed += $this->reIndex($className, $batchSize, $safe);
+            try {
+                $nIndexed += $this->reIndex($className, $batchSize, $safe);
+            } catch (NotAnAlgoliaEntity $e) {
+                $output->writeln("<info>Skipped $className which isn't an entity to index.</info>");
+            }
         }
 
         if ($input->getOption('sync')) {

--- a/Indexer/ManualIndexer.php
+++ b/Indexer/ManualIndexer.php
@@ -169,7 +169,7 @@ class ManualIndexer
 
         if (!$this->indexer->discoverEntity($className, $this->objectManager)) {
             throw new NotAnAlgoliaEntity(
-                'Tried to index entity of class `'.get_class($className).'`, which is not recognized as an entity to index.'
+                'Tried to clear index for entity of class `'.$className.'`, which is not recognized as an entity to index.'
             );
         }
 
@@ -208,7 +208,7 @@ class ManualIndexer
 
         if (!$this->indexer->discoverEntity($className, $this->objectManager)) {
             throw new NotAnAlgoliaEntity(
-                'Tried to index entity of class `'.$className.'`, which is not recognized as an entity to index.'
+                'Tried to reindex entity of class `'.$className.'`, which is not recognized as an entity to index.'
             );
         }
 

--- a/Tests/AlgoliaSearch/ODM/ClearCommandTest.php
+++ b/Tests/AlgoliaSearch/ODM/ClearCommandTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Algolia\AlgoliaSearchBundle\Tests\AlgoliaSearch\ODM;
+
+use Algolia\AlgoliaSearchBundle\Tests\AlgoliaSearch\ClearCommandTest as BaseClearCommandTest;
+use Algolia\AlgoliaSearchBundle\Tests\Traits\ODMTestTrait;
+
+class ClearCommandTest extends BaseClearCommandTest
+{
+    use ODMTestTrait;
+
+    protected function getCommandOptions()
+    {
+        return ['--dm' => 'default'];
+    }
+}

--- a/Tests/AlgoliaSearch/ORM/ClearCommandTest.php
+++ b/Tests/AlgoliaSearch/ORM/ClearCommandTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Algolia\AlgoliaSearchBundle\Tests\AlgoliaSearch\ORM;
+
+use Algolia\AlgoliaSearchBundle\Tests\AlgoliaSearch\ClearCommandTest as BaseClearCommandTest;
+use Algolia\AlgoliaSearchBundle\Tests\Traits\ORMTestTrait;
+
+class ClearCommandTest extends BaseClearCommandTest
+{
+    use ORMTestTrait;
+
+    protected function getCommandOptions()
+    {
+        return ['--em' => 'default'];
+    }
+}


### PR DESCRIPTION
When invoking the clear or reindex command for all known entities the command will fail if at least one entity is not Algolia mapped. This is inkonsistent regarding the settings command and makes it
difficult in automation processes.

By adding a new optional command line settings this kind of error can be skipped. By default the command behavior is not changing (BC).