### PR TITLE
Fix entity discovery for discriminated entities

### DIFF
--- a/Indexer/Indexer.php
+++ b/Indexer/Indexer.php
@@ -311,19 +311,15 @@ class Indexer
                 return null;
             }
 
-            $value = $value->toArray();
-
-            if (count($value) > 0) {
-                if (! $this->discoverEntity(reset($value), $this->objectManager)) {
+            $value = array_map(function ($val) use ($field, $depth) {
+                if (! $this->discoverEntity($val, $this->objectManager)) {
                     throw new NotAnAlgoliaEntity(
-                        'Tried to index `'.$field.'` relation which is a `'.get_class(reset($value)).'` instance, which is not recognized as an entity to index.'
+                        'Tried to index `'.$field.'` relation which is a `'.get_class($val).'` instance, which is not recognized as an entity to index.'
                     );
                 }
-            }
 
-            $value = array_map(function ($val) use ($depth) {
                 return $this->getFieldsForAlgolia($val, null, $depth + 1);
-            }, $value);
+            }, $value->toArray());
         }
 
         if (is_object($value) && $this->isEntity($this->objectManager, $value)) {

--- a/Tests/AlgoliaSearch/DiscriminatedAssociationTest.php
+++ b/Tests/AlgoliaSearch/DiscriminatedAssociationTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Algolia\AlgoliaSearchBundle\Tests\AlgoliaSearch;
+
+use Algolia\AlgoliaSearchBundle\Tests\BaseTest;
+use Algolia\AlgoliaSearchBundle\Tests\Entity\ProductWithDiscriminatedAssociation;
+
+abstract class DiscriminatedAssociationTest extends BaseTest
+{
+    /**
+     * Here we really want to test the full integration
+     * and talk with Algolia servers.
+     */
+    public static $isolateFromAlgolia = false;
+
+    public function tearDown()
+    {
+        parent::tearDown();
+        $this->getIndexer()->deleteIndex('ProductWithDiscriminatedEmbedTest');
+        $this->getIndexer()->waitForAlgoliaTasks();
+    }
+
+    public function testManualIndexingWithDiscriminatedEntity()
+    {
+        $document = new ProductWithDiscriminatedAssociation();
+        static::staticGetObjectManager()->persist($document);
+
+        $nIndexed = $this->getIndexer()->getManualIndexer($this->getObjectManager())->index($document);
+
+        $this->assertEquals(
+            1,
+            $nIndexed
+        );
+    }
+}

--- a/Tests/AlgoliaSearch/ODM/DiscriminatedAssociationTest.php
+++ b/Tests/AlgoliaSearch/ODM/DiscriminatedAssociationTest.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Algolia\AlgoliaSearchBundle\Tests\AlgoliaSearch\ODM;
+
+use Algolia\AlgoliaSearchBundle\Tests\AlgoliaSearch\DiscriminatedAssociationTest as BaseDiscriminatedAssociationTest;
+use Algolia\AlgoliaSearchBundle\Tests\Traits\ODMTestTrait;
+
+class DiscriminatedAssociationTest extends BaseDiscriminatedAssociationTest
+{
+    use ODMTestTrait;
+}

--- a/Tests/AlgoliaSearch/ORM/DiscriminatedAssociationTest.php
+++ b/Tests/AlgoliaSearch/ORM/DiscriminatedAssociationTest.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Algolia\AlgoliaSearchBundle\Tests\AlgoliaSearch\ORM;
+
+use Algolia\AlgoliaSearchBundle\Tests\AlgoliaSearch\DiscriminatedAssociationTest as BaseDiscriminatedAssociationTest;
+use Algolia\AlgoliaSearchBundle\Tests\Traits\ORMTestTrait;
+
+class DiscriminatedAssociationTest extends BaseDiscriminatedAssociationTest
+{
+    use ORMTestTrait;
+}

--- a/Tests/Entity/ProductWithDiscriminatedAssociation.php
+++ b/Tests/Entity/ProductWithDiscriminatedAssociation.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Algolia\AlgoliaSearchBundle\Tests\Entity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\ORM\Mapping as ORM;
+use Algolia\AlgoliaSearchBundle\Mapping\Annotation as Algolia;
+
+/**
+ * @ORM\Entity
+ * @ODM\Document
+ *
+ * @Algolia\Index
+ */
+class ProductWithDiscriminatedAssociation extends BaseTestAwareEntity
+{
+    /**
+     * @var integer
+     *
+     * @ORM\Column(name="id", type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     *
+     * @ODM\Id(strategy="increment")
+     */
+    protected $id;
+
+    /**
+     * @var Collection
+     *
+     * @ORM\OneToMany(targetEntity=AbstractAssociation::class, mappedBy="owner", cascade={"persist", "remove"})
+     * @ODM\ReferenceMany(targetDocument=AbstractAssociation::class, cascade={"persist", "remove"})
+     *
+     * @Algolia\Attribute
+     */
+    protected $associations;
+
+    public function __construct()
+    {
+        $this->id = 1;
+        $this->associations = new ArrayCollection([
+            new AssociationA('a'),
+            new AssociationB('b'),
+        ]);
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getAssociations()
+    {
+        return $this->associations;
+    }
+}
+
+/**
+ * @ORM\MappedSuperclass
+ * @ORM\DiscriminatorColumn(name="type", type="string")
+ * @ORM\DiscriminatorMap({
+ *     "a"=AssociationA::class,
+ *     "b"=AssociationB::class,
+ * })
+ * @ODM\MappedSuperclass
+ * @ODM\DiscriminatorField("type")
+ * @ODM\DiscriminatorMap({
+ *     "a"=AssociationA::class,
+ *     "b"=AssociationB::class,
+ * })
+ *
+ * @Algolia\Index(autoIndex=false)
+ */
+class AbstractAssociation
+{
+    /**
+     * @var integer
+     *
+     * @ORM\Column(name="id", type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     *
+     * @ODM\Id(strategy="increment")
+     */
+    protected $id;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="name", type="string", length=255)
+     * @ODM\Field(type="string")
+     *
+     * @Algolia\Attribute
+     */
+    protected $name;
+
+    /**
+     * @var ProductWithDiscriminatedAssociation
+     *
+     * @ORM\ManyToOne(targetEntity=ProductWithDiscriminatedAssociation::class, inversedBy="associations")
+     * @ORM\JoinColumn(name="owner_id", nullable=true)
+     * @ODM\ReferenceOne(targetDocument=ProductWithDiscriminatedAssociation::class, mappedBy="associations")
+     */
+    protected $owner;
+
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function getOwner()
+    {
+        return $this->owner;
+    }
+}
+
+/**
+ * @ORM\Entity
+ * @ODM\Document
+ */
+class AssociationA extends AbstractAssociation
+{
+}
+
+/**
+ * @ORM\Entity
+ * @ODM\Document
+ */
+class AssociationB extends AbstractAssociation
+{
+}


### PR DESCRIPTION
Entities with `toMany` relationships that target discriminated entities are not properly discovered when using `ManualIndexer`: only the first entity is used to load Metadata, while subsequent elements in the collection may be of a different class. This pull request changes metadata loading to happen for every element. From a performance perspective, the change should be negligible - `discoverEntity` checks whether the class metadata has already been loaded and doesn't trigger a loading cycle if so.