### PR TITLE
Require stable Symfony versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,12 +12,11 @@
             "email": "contact@algolia.com"
         }
     ],
-    "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
         "algolia/algoliasearch-client-php": "^1.23",
-        "symfony/serializer": "^3.4-RC2 || ^4.0-RC2",
-        "symfony/property-access": "^3.4-RC2 || ^4.0-RC2"
+        "symfony/serializer": "^3.4.0 || ^4.0.0",
+        "symfony/property-access": "^3.4.0 || ^4.0.0"
     },
     "autoload": {
         "psr-4": {
@@ -30,11 +29,16 @@
         }
     },
     "require-dev": {
-        "symfony/framework-bundle": "^3.4-RC2 || ^4.0-RC2",
+        "symfony/framework-bundle": "^3.4.0 || ^4.0.0",
         "phpunit/phpunit": "^5.7",
         "doctrine/doctrine-bundle": "^1.7",
-        "symfony/doctrine-bridge": "^3.4-RC2 || ^4.0-RC2",
+        "symfony/doctrine-bridge": "^3.4.0 || ^4.0.0",
         "doctrine/orm": "^2.5",
-        "symfony/var-dumper": "^3.3"
+        "symfony/var-dumper": "^3.3 || ^4.0.0"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "3.0.x-dev"
+        }
     }
 }


### PR DESCRIPTION
With the release of Symfony 3.4.0 and 4.0.0, there's no need to require RC versions.

In addition to that, this PR also marks `dev-master` as branch alias for `3.0.x` in composer.json.