### PR TITLE
[3.0] Fixes custom normalizer usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,15 @@ class CommentNormalizer implements NormalizerInterface
 
 You have to register your normalizer as a service and expose your service a a public one. (`public=true`)
 
+If you want to use built-in `Normalizer` from Symfony, you have to redefine their service to expose them as public:
+
+```xml
+<service public="true" id="serializer.normalizer.datetime" class="Symfony\Component\Serializer\Normalizer\DateTimeNormalizer">
+      <!-- Run before serializer.normalizer.object -->
+      <tag name="serializer.normalizer" priority="-910" />
+</service>
+```
+
 ## Engine
 
 ### The `NullEngine`

--- a/README.md
+++ b/README.md
@@ -62,9 +62,10 @@ algolia_search:
     - name: comments
       class: App\Entity\Comment
       normalizers:
-        - App\Normalizers\CommentNormalizer
-        - Symfony\Component\Serializer\Normalizer\CustomNormalizer
-        - Algolia\SearchBundle\Normalizer\SearchableArrayNormalizer
+        # service id of normalizers
+        - comment_normalizer
+        - datetime_normalizer
+        - algolia_searchable_array_normalizer
 
 ```
 
@@ -222,6 +223,8 @@ class CommentNormalizer implements NormalizerInterface
     }
 }
 ```
+
+You have to register your normalizer as a service and expose your service a a public one. (`public=true`)
 
 ## Engine
 

--- a/src/DependencyInjection/AlgoliaSearchExtension.php
+++ b/src/DependencyInjection/AlgoliaSearchExtension.php
@@ -35,7 +35,7 @@ class AlgoliaSearchExtension extends Extension
 
         $container->setParameter('algolia_search.doctrineSubscribedEvents', $config['doctrineSubscribedEvents']);
 
-        $indexManagerDefinition = (new Definition(
+        $indexManagerDefinition = new Definition(
             IndexManager::class,
             [
                 new Reference('search.engine'),
@@ -43,7 +43,11 @@ class AlgoliaSearchExtension extends Extension
                 $prefix,
                 $config['nbResults']
             ]
-        ))->setPublic(true);
+        );
+        $indexManagerDefinition
+            ->addMethodCall('setContainer', [new Reference('service_container')])
+            ->setPublic(true)
+        ;
 
         $container->setDefinition('search.index_manager', $indexManagerDefinition);
     }

--- a/src/IndexManager.php
+++ b/src/IndexManager.php
@@ -196,6 +196,11 @@ class IndexManager implements IndexingManagerInterface, SearchManagerInterface
             $normalizerServices[] = $this->container->get($normalizerServiceId);
         }
 
+        // if no normalizer service found, we grab the default normalizer
+        if (count($normalizerServices) == 0) {
+            $normalizerServices = $this->container->get('algolia_searchable_array_normalizer');
+        }
+
         return $normalizerServices;
     }
 

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -21,6 +21,9 @@
             <argument type="service" id="algolia_client" />
         </service>
 
+        <service id="algolia_searchable_array_normalizer" class="Algolia\SearchBundle\Normalizer\SearchableArrayNormalizer" public="true">
+        </service>
+
     </services>
 
 </container>

--- a/src/SearchableEntity.php
+++ b/src/SearchableEntity.php
@@ -19,7 +19,7 @@ class SearchableEntity implements SearchableEntityInterface
         $this->indexName = $indexName;
         $this->entity = $entity;
         $this->entityMetadata = $entityMetadata;
-        $this->normalizers = $normalizers ?? [new SearchableArrayNormalizer()];
+        $this->normalizers = $normalizers;
 
         $this->setId();
     }

--- a/src/SearchableEntity.php
+++ b/src/SearchableEntity.php
@@ -19,7 +19,7 @@ class SearchableEntity implements SearchableEntityInterface
         $this->indexName = $indexName;
         $this->entity = $entity;
         $this->entityMetadata = $entityMetadata;
-        $this->normalizers = $normalizer ?? [new SearchableArrayNormalizer()];
+        $this->normalizers = $normalizers ?? [new SearchableArrayNormalizer()];
 
         $this->setId();
     }


### PR DESCRIPTION
TLDR: You shouldn't merge this PR, merge #153 instead ✌️

---

This PR solves 2 problems:

1. Custom normalizer not being called (#144)
2. Normalizer passed as class name instead of object instance (#148). this one is little more complicated than just instanciating the object via the `new` keyword because you can define `Normalizer` as a service and in that case the `Normalizer` would break. So I had to inject the container instead and loop on service id.

Note that it has some (**MAJOR**) drawbacks:
- You have to set the `Normalizer` attribute `public=true` when defining your custom `Normalizer` service.
- You have to overwrite built-in Symfony Normalizer services to expose them as public, otherwise you cannot use them.
- You have to EXPLICITLY tell all the `Normalizers` dependencies. If you object has for example 10 relations to other objects, you have to add those 10 `Normalizers` in your indice configuration

Fix #144 and #148 

Disclaimer: I didn't test if I broke indexing entities via implementing the `normalize` method on the entity itself.

Also, after thinking through this on my way home, I've decided that **#153 is a much more elegent solution**.