### PR TITLE
[3.0] call detach on the object manager to allow GC working

### DIFF
--- a/src/IndexManager.php
+++ b/src/IndexManager.php
@@ -66,6 +66,8 @@ class IndexManager implements IndexingManagerInterface, SearchManagerInterface
                     $objectManager->getClassMetadata($className),
                     $this->getNormalizer($className)
                 );
+
+                $objectManager->detach($entity);
             }
 
             $this->engine->update($searchableEntities);
@@ -92,6 +94,8 @@ class IndexManager implements IndexingManagerInterface, SearchManagerInterface
                     $objectManager->getClassMetadata($className),
                     $this->getNormalizer($className)
                 );
+
+                $objectManager->detach($entity);
             }
 
             $this->engine->delete($searchableEntities);


### PR DESCRIPTION
On my dataset (~38,000) objects, this reduce a little the consumed memory, I couldn't tell how much because without the patch, the blackfire comparaison wouldn't even complete.
I couldn't perform a blackfire comparaison because i'm not a premium blackfire user.

## Before patching
<img width="919" alt="1__app_seek-team___srv_app__ssh_" src="https://user-images.githubusercontent.com/346010/33517837-6eb5754c-d78b-11e7-8a74-90ce6b2eb82e.png">

## After patching
With the patch, the blackfire could finish:
link to profiling (I think only accessible 24hours) https://blackfire.io/profiles/946f3715-ac68-4c0e-ba08-79aa2c2b1812/graph

![cv___prod___avec_patch_profile_-_blackfire](https://user-images.githubusercontent.com/346010/33517849-98d53b5a-d78b-11e7-85f3-59b3f8a8b4bc.png)
![cv___prod___avec_patch_profile_-_blackfire](https://user-images.githubusercontent.com/346010/33517858-c8110dd6-d78b-11e7-9fb2-6ff89fbbca1b.png)

Note: This a small step, but for huge dataset, you might consider using yielding, iterator, and all other fancy stuff that could greatly help users with large dataset use the minimum memory possible like:

```php 
$iterableResult = $doctrine->getManager()->createQuery("SELECT x FROM Entity y")->iterate();

while (($row = $iterableResult->next()) !== false) {
    $object = $row[0];
}
``` 