### PR TITLE
[3.0] Do NOT try to index non-indexable entities

### DIFF
--- a/src/EventListener/SearchIndexerSubscriber.php
+++ b/src/EventListener/SearchIndexerSubscriber.php
@@ -2,7 +2,6 @@
 
 namespace Algolia\SearchBundle\EventListener;
 
-
 use Algolia\SearchBundle\IndexManager;
 use Doctrine\Common\EventSubscriber;
 use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
@@ -39,13 +38,17 @@ class SearchIndexerSubscriber implements EventSubscriber
         $object = $args->getObject();
         $objectManager = $args->getObjectManager();
 
-        $this->indexManager->index($object, $objectManager);
+        if ($this->indexManager->isSearchable($object)) {
+            $this->indexManager->index($object, $objectManager);
+        }
     }
 
     public function preRemove(LifecycleEventArgs $args)
     {
         $object = $args->getObject();
 
-        $this->indexManager->remove($object, $args->getObjectManager());
+        if ($this->indexManager->isSearchable($object)) {
+            $this->indexManager->remove($object, $args->getObjectManager());
+        }
     }
 }


### PR DESCRIPTION
Fixes #156 

The check to see if an entity should be indexed was never called. Only the assertion responsible for throwing an exception as a last resort.

So when you updated any other Entity in your application, the search bundle would throw an exception in any cases.

With the fix, the subscriber don't call the IndexManager if the object is not configured as indexable.