### PR TITLE
Expose configuration

### DIFF
--- a/src/Command/IndexCommand.php
+++ b/src/Command/IndexCommand.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Algolia\SearchBundle\Command;
+
+
+use Algolia\SearchBundle\IndexingManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+abstract class IndexCommand extends ContainerAwareCommand
+{
+    protected function getEntitiesFromArgs(InputInterface $input, OutputInterface $output, IndexingManagerInterface $indexManager)
+    {
+        if ($input->getOption('all')) {
+            return $indexManager->getSearchableEntities();
+        }
+
+        $entities = [];
+        $indexNames = $input->getArgument('indexNames');
+        $config = $indexManager->getConfiguration();
+
+        foreach ($indexNames as $name) {
+            if (isset($config['indices'][$name])) {
+                $entities[] = $config['indices'][$name]['class'];
+            } else {
+                $output->writeln('<comment>No index named <info>'.$name.'</info> was found. Check you configuration.</comment>');
+            }
+        }
+
+        return $entities;
+    }
+}

--- a/src/Command/SearchClearCommand.php
+++ b/src/Command/SearchClearCommand.php
@@ -3,28 +3,27 @@
 namespace Algolia\SearchBundle\Command;
 
 
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class SearchClearCommand extends ContainerAwareCommand
+class SearchClearCommand extends IndexCommand
 {
     protected function configure()
     {
         $this
             ->setName('search:clear')
             ->setDescription('Clear index (remove all)')
-            ->addArgument('indexNames', InputArgument::IS_ARRAY | InputArgument::OPTIONAL, 'Index to clear')
-            ->addOption('all', false, InputOption::VALUE_NONE, 'Reindex everything?');
+            ->addArgument('indexNames', InputArgument::IS_ARRAY | InputArgument::OPTIONAL, 'Name of the index to clear (without prefix)')
+            ->addOption('all', false, InputOption::VALUE_NONE, 'Clear all indices');
         ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $indexManager = $this->getContainer()->get('search.index_manager');
-        $indexToClear = $this->getIndexToClear($input, $indexManager);
+        $indexToClear = $this->getEntitiesFromArgs($input, $output, $indexManager);
 
         foreach ($indexToClear as $indexName) {
             $indexManager->clear($indexName);
@@ -33,14 +32,5 @@ class SearchClearCommand extends ContainerAwareCommand
         }
 
         $output->writeln('<info>Done!</info>');
-    }
-
-    private function getIndexToClear($input, $indexManager)
-    {
-        if ($input->getOption('all')) {
-            return array_keys($indexManager->getIndexConfiguration());
-        }
-
-        return $input->getArgument('indexNames');
     }
 }

--- a/src/Command/SearchImportCommand.php
+++ b/src/Command/SearchImportCommand.php
@@ -2,14 +2,13 @@
 
 namespace Algolia\SearchBundle\Command;
 
-use Algolia\SearchBundle\IndexingManagerInterface;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class SearchImportCommand extends ContainerAwareCommand
+class SearchImportCommand extends IndexCommand
 {
     protected function configure()
     {
@@ -25,7 +24,7 @@ class SearchImportCommand extends ContainerAwareCommand
     {
         $indexManager = $this->getContainer()->get('search.index_manager');
         $doctrine = $this->getContainer()->get('doctrine');
-        $entitiesToIndex = $this->getEntitiesToIndex($input, $output, $indexManager);
+        $entitiesToIndex = $this->getEntitiesFromArgs($input, $output, $indexManager);
 
         foreach ($entitiesToIndex as $entityClassName) {
             $repository = $doctrine->getRepository($entityClassName);
@@ -39,26 +38,5 @@ class SearchImportCommand extends ContainerAwareCommand
         }
 
         $output->writeln('<info>Done!</info>');
-    }
-
-    private function getEntitiesToIndex(InputInterface $input, OutputInterface $output, IndexingManagerInterface $indexManager)
-    {
-        if ($input->getOption('all')) {
-            return $indexManager->getSearchableEntities();
-        }
-
-        $entities = [];
-        $indexNames = $input->getArgument('indexNames');
-        $config = $indexManager->getConfiguration();
-
-        foreach ($indexNames as $name) {
-            if (isset($config['indices'][$name])) {
-                $entities[] = $config['indices'][$name]['class'];
-            } else {
-                $output->writeln('<comment>No index named <info>'.$name.'</info> was found. Check you configuration.</comment>');
-            }
-        }
-
-        return $entities;
     }
 }

--- a/src/DependencyInjection/AlgoliaSearchExtension.php
+++ b/src/DependencyInjection/AlgoliaSearchExtension.php
@@ -28,9 +28,8 @@ class AlgoliaSearchExtension extends Extension
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
-        $prefix = $config['prefix'];
-        if (is_null($prefix)) {
-            $prefix = $container->getParameter("kernel.environment").'_';
+        if (is_null($config['prefix'])) {
+            $config['prefix'] = $container->getParameter("kernel.environment").'_';
         }
 
         $container->setParameter('algolia_search.doctrineSubscribedEvents', $config['doctrineSubscribedEvents']);
@@ -40,9 +39,7 @@ class AlgoliaSearchExtension extends Extension
             [
                 new Reference('serializer'),
                 new Reference('search.engine'),
-                $config['indices'],
-                $prefix,
-                $config['nbResults']
+                $config
             ]
         ))->setPublic(true);
 

--- a/src/IndexingManagerInterface.php
+++ b/src/IndexingManagerInterface.php
@@ -11,6 +11,8 @@ interface IndexingManagerInterface
 
     public function getSearchableEntities();
 
+    public function getConfiguration();
+
     public function getFullIndexName($className);
 
     public function index($entity, ObjectManager $objectManager);


### PR DESCRIPTION
Many times I needed the configuration but I wanted to avoid exposing it. In the end, I believe it should be easily accessible. Having only one argument in the constructor will make the index manager more extensible.

This PR will:
- [x] Expose the whole bundle configuration
- [x] Require import command to pass index name instead of entity class name (fix #143)
