### PR TITLE
Register CustomNormalizer by default

### DIFF
--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -26,6 +26,11 @@
             <argument type="service" id="algolia_client" />
         </service>
 
+        <!-- CustomNormalizer is not registered by framework-bundle -->
+        <service class="Symfony\Component\Serializer\Normalizer\CustomNormalizer">
+            <tag name="serializer.normalizer" priority="-800" />
+        </service>
+
     </services>
 
 </container>


### PR DESCRIPTION
Since we removed the SearchableArrayNormalizer we broke the behavior explained here. It was supposed to rely on the `CustomNormalizer` that ship with the serializer component but the framework-bundle doesn't register it by default.

This shows that I need to setup Travis and add more tests ASAP.