### PR TITLE
Add a compiler pass for checking requirements

### DIFF
--- a/src/AlgoliaSearchBundle.php
+++ b/src/AlgoliaSearchBundle.php
@@ -3,6 +3,8 @@
 namespace Algolia\SearchBundle;
 
 use AlgoliaSearch\Version;
+use Algolia\SearchBundle\DependencyInjection\SearchRequirementsPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\HttpKernel\Kernel as SfKernel;
 
@@ -14,5 +16,12 @@ class AlgoliaSearchBundle extends Bundle
 
         Version::addSuffixUserAgentSegment('Symfony', SfKernel::VERSION);
         Version::addSuffixUserAgentSegment('Symfony Search Bundle', '3.0.0-BETA');
+    }
+    
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
+
+        $container->addCompilerPass(new SearchRequirementsPass());
     }
 }

--- a/src/DependencyInjection/SearchRequirementsPass.php
+++ b/src/DependencyInjection/SearchRequirementsPass.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Algolia\SearchBundle\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\PriorityTaggedServiceTrait;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
+
+class SearchRequirementsPass implements CompilerPassInterface
+{
+    use PriorityTaggedServiceTrait;
+
+    public function process(ContainerBuilder $container)
+    {
+        $servicesNeeded = ['serializer'];
+
+        foreach ($servicesNeeded as $service) {
+            if (!$container->has($service)) {
+                throw new LogicException(sprintf('No "%s" service found. Read
+                more: http://www.algolia.com/doc/api-client/symfony/troubleshooting/', $service));
+            }
+        }
+    }
+}


### PR DESCRIPTION
I am hesitant to add this. It's could be nice but I'm not sure it's so useful.

Does anyone see any downside?
  
---
EDIT:

`symfony/serializer` is required but the [service configuration is in the framework bundle](https://github.com/symfony/framework-bundle/blob/master/Resources/config/serializer.xml), not in the component. By default, [it's not always enabled](https://github.com/symfony/symfony-standard/blob/3.4/app/config/config.yml#L21), you need to do it amnually in your configuration. I added a note in the soon-to-be-published doc.

I believe most people enable it in their app but if you're getting started, you might not understand the error.

To enable it (without annotations)
```yaml
framework:
    serializer: { enable: true }
```