### PR TITLE
Better dependency injections

### DIFF
--- a/src/Command/IndexCommand.php
+++ b/src/Command/IndexCommand.php
@@ -19,11 +19,11 @@ abstract class IndexCommand extends ContainerAwareCommand
             $indexNames = explode(',', $indexList);
         }
 
-        if (empty($indexNames)) {
-            return $indexManager->getSearchableEntities();
-        }
-
         $config = $indexManager->getConfiguration();
+
+        if (empty($indexNames)) {
+            $indexNames = array_keys($config['indices']);
+        }
 
         foreach ($indexNames as $name) {
             if (isset($config['indices'][$name])) {

--- a/src/Command/IndexCommand.php
+++ b/src/Command/IndexCommand.php
@@ -4,13 +4,22 @@ namespace Algolia\SearchBundle\Command;
 
 
 use Algolia\SearchBundle\IndexManagerInterface;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-abstract class IndexCommand extends ContainerAwareCommand
+abstract class IndexCommand extends Command
 {
-    protected function getEntitiesFromArgs(InputInterface $input, OutputInterface $output, IndexManagerInterface $indexManager)
+    protected $indexManager;
+
+    public function __construct(IndexManagerInterface $indexManager)
+    {
+        $this->indexManager = $indexManager;
+
+        parent::__construct();
+    }
+
+    protected function getEntitiesFromArgs(InputInterface $input, OutputInterface $output)
     {
         $entities = [];
         $indexNames = [];
@@ -19,7 +28,7 @@ abstract class IndexCommand extends ContainerAwareCommand
             $indexNames = explode(',', $indexList);
         }
 
-        $config = $indexManager->getConfiguration();
+        $config = $this->indexManager->getConfiguration();
 
         if (empty($indexNames)) {
             $indexNames = array_keys($config['indices']);

--- a/src/Command/SearchClearCommand.php
+++ b/src/Command/SearchClearCommand.php
@@ -25,11 +25,10 @@ class SearchClearCommand extends IndexCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $indexManager = $this->getContainer()->get('search.index_manager');
-        $indexToClear = $this->getEntitiesFromArgs($input, $output, $indexManager);
+        $indexToClear = $this->getEntitiesFromArgs($input, $output);
 
         foreach ($indexToClear as $indexName => $className) {
-            $indexManager->clear($className);
+            $this->indexManager->clear($className);
 
             $output->writeln('Cleared <info>'.$indexName.'</info> index of <comment>'.$className.'</comment> ');
         }

--- a/src/Command/SearchImportCommand.php
+++ b/src/Command/SearchImportCommand.php
@@ -26,9 +26,8 @@ class SearchImportCommand extends IndexCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $indexManager = $this->getContainer()->get('search.index_manager');
         $doctrine = $this->getContainer()->get('doctrine');
-        $entitiesToIndex = $this->getEntitiesFromArgs($input, $output, $indexManager);
+        $entitiesToIndex = $this->getEntitiesFromArgs($input, $output);
 
         foreach ($entitiesToIndex as $indexName => $entityClassName) {
             $repository = $doctrine->getRepository($entityClassName);
@@ -36,7 +35,7 @@ class SearchImportCommand extends IndexCommand
 
             $entities = $repository->findAll();
 
-            $indexManager->index($entities, $manager);
+            $this->indexManager->index($entities, $manager);
 
             $output->writeln(sprintf(
                 'Indexed %s %s entities into %s index',

--- a/src/Command/SearchSettingsBackupCommand.php
+++ b/src/Command/SearchSettingsBackupCommand.php
@@ -21,8 +21,8 @@ class SearchSettingsBackupCommand extends SearchSettingsCommand
             );
     }
 
-    protected function handle(SettingsManagerInterface $settingsManager, $params)
+    protected function handle($params)
     {
-        return $settingsManager->backup($params);
+        return $this->settingsManager->backup($params);
     }
 }

--- a/src/Command/SearchSettingsCommand.php
+++ b/src/Command/SearchSettingsCommand.php
@@ -3,12 +3,21 @@
 namespace Algolia\SearchBundle\Command;
 
 use Algolia\SearchBundle\Settings\SettingsManagerInterface;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-abstract class SearchSettingsCommand extends ContainerAwareCommand
+abstract class SearchSettingsCommand extends Command
 {
+    protected $settingsManager;
+
+    public function __construct(SettingsManagerInterface $settingsManager)
+    {
+        $this->settingsManager = $settingsManager;
+
+        parent::__construct();
+    }
+
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         if ($indexList = $input->getOption('indices')) {
@@ -20,12 +29,10 @@ abstract class SearchSettingsCommand extends ContainerAwareCommand
             'extra' => $input->getArgument('extra'),
         ];
 
-        $settingsManager = $this->getContainer()->get('search.settings_manager');
-
-        $message = $this->handle($settingsManager, $params);
+        $message = $this->handle($params);
 
         $output->writeln($message);
     }
 
-    abstract protected function handle(SettingsManagerInterface $settingsManager, $params);
+    abstract protected function handle($params);
 }

--- a/src/Command/SearchSettingsPushCommand.php
+++ b/src/Command/SearchSettingsPushCommand.php
@@ -21,8 +21,8 @@ class SearchSettingsPushCommand extends SearchSettingsCommand
             );
     }
 
-    protected function handle(SettingsManagerInterface $settingsManager, $params)
+    protected function handle($params)
     {
-        return $settingsManager->push($params);
+        return $this->settingsManager->push($params);
     }
 }

--- a/src/IndexManager.php
+++ b/src/IndexManager.php
@@ -73,7 +73,6 @@ class IndexManager implements IndexManagerInterface
 
             $this->engine->update($searchableEntities);
         }
-
     }
 
     public function remove($entities, ObjectManager $objectManager)

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -27,6 +27,7 @@
         </service>
 
         <service id="Algolia\SearchBundle\IndexManagerInterface" alias="search.index_manager"/>
+        <service id="Algolia\SearchBundle\Settings\SettingsManagerInterface" alias="search.settings_manager"/>
 
         <!-- CustomNormalizer is not registered by framework-bundle -->
         <service id="custom_normalizer" class="Symfony\Component\Serializer\Normalizer\CustomNormalizer" public="false">

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -6,7 +6,7 @@
 
     <services>
 
-        <prototype namespace="Algolia\SearchBundle\Command\" resource="../../Command">
+        <prototype namespace="Algolia\SearchBundle\Command\" resource="../../Command" autowire="true">
             <tag name="console.command" />
         </prototype>
 


### PR DESCRIPTION
A few different bug fix have been added to this branch:

- [x] Necessary services are injected in commands, not grabbed from the container
- [x] Forgotten `IndexSettingsInterface` service was declared (necessary for autowiring (see #185)
- [x] Also fix bug with command not displaying index names in some cases
  
  
  