### PR TITLE
Move UA definition to Kernel::boot and add Sf version

### DIFF
--- a/src/AlgoliaSearchBundle.php
+++ b/src/AlgoliaSearchBundle.php
@@ -2,8 +2,17 @@
 
 namespace Algolia\SearchBundle;
 
+use AlgoliaSearch\Version;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Symfony\Component\HttpKernel\Kernel as SfKernel;
 
 class AlgoliaSearchBundle extends Bundle
 {
+    public function boot()
+    {
+        parent::boot();
+
+        Version::addSuffixUserAgentSegment('Symfony', SfKernel::VERSION);
+        Version::addSuffixUserAgentSegment('Symfony Search Bundle', '3.0.0-BETA');
+    }
 }

--- a/src/Engine/AlgoliaEngine.php
+++ b/src/Engine/AlgoliaEngine.php
@@ -4,7 +4,6 @@ namespace Algolia\SearchBundle\Engine;
 
 use Algolia\SearchBundle\SearchableEntityInterface;
 use AlgoliaSearch\Client;
-use AlgoliaSearch\Version;
 
 class AlgoliaEngine implements EngineInterface
 {
@@ -13,8 +12,6 @@ class AlgoliaEngine implements EngineInterface
 
     public function __construct(Client $algolia)
     {
-        Version::addSuffixUserAgentSegment('Symfony Search Bundle', '3.0.0-BETA');
-
         $this->algolia = $algolia;
     }
 


### PR DESCRIPTION
- [x] Move User-Agent to `Bundle::boot` in case custom engine is used, or client is used without the engine
- [x] Add Symfony version to Algolia UserAgent (fix #177)