### PR TITLE
Change engine return type

### DIFF
--- a/src/Command/SearchClearCommand.php
+++ b/src/Command/SearchClearCommand.php
@@ -28,9 +28,13 @@ class SearchClearCommand extends IndexCommand
         $indexToClear = $this->getEntitiesFromArgs($input, $output);
 
         foreach ($indexToClear as $indexName => $className) {
-            $this->indexManager->clear($className);
+            $success = $this->indexManager->clear($className);
 
-            $output->writeln('Cleared <info>'.$indexName.'</info> index of <comment>'.$className.'</comment> ');
+            if ($success) {
+                $output->writeln('Cleared <info>'.$indexName.'</info> index of <comment>'.$className.'</comment> ');
+            } else {
+                $output->writeln('<error>Index <info>'.$indexName.'</info>  couldn\'t be cleared</error>');
+            }
         }
 
         $output->writeln('<info>Done!</info>');

--- a/src/Command/SearchImportCommand.php
+++ b/src/Command/SearchImportCommand.php
@@ -28,6 +28,7 @@ class SearchImportCommand extends IndexCommand
     {
         $doctrine = $this->getContainer()->get('doctrine');
         $entitiesToIndex = $this->getEntitiesFromArgs($input, $output);
+        $config = $this->indexManager->getConfiguration();
 
         foreach ($entitiesToIndex as $indexName => $entityClassName) {
             $repository = $doctrine->getRepository($entityClassName);
@@ -35,13 +36,14 @@ class SearchImportCommand extends IndexCommand
 
             $entities = $repository->findAll();
 
-            $this->indexManager->index($entities, $manager);
+            $response = $this->indexManager->index($entities, $manager);
 
             $output->writeln(sprintf(
-                'Indexed %s %s entities into %s index',
-                '<comment>'.count($entities).'</comment>',
+                'Indexed <comment>%s / %s</comment> %s entities into %s index',
+                $response[$indexName],
+                count($entities),
                 $entityClassName,
-                '<info>'.$indexName.'</info>'
+                '<info>'.$config['prefix'].$indexName.'</info>'
             ));
         }
 

--- a/src/Engine/AlgoliaEngine.php
+++ b/src/Engine/AlgoliaEngine.php
@@ -51,16 +51,24 @@ class AlgoliaEngine implements EngineInterface
 
     public function clear($indexName)
     {
-        return [
-            $indexName => $this->algolia->initIndex($indexName)->clearIndex()
-        ];
+        try {
+            $this->doClear($indexName);
+        } catch (\Exception $e) {
+            return false;
+        }
+
+        return true;
     }
 
     public function delete($indexName)
     {
-        return [
-            $indexName => $this->algolia->deleteIndex($indexName)
-        ];
+        try {
+            $this->doDelete($indexName);
+        } catch (\Exception $e) {
+            return false;
+        }
+
+        return true;
     }
 
     public function search($query, $indexName, $page = 1, $nbResults = null, array $parameters = [])
@@ -140,5 +148,19 @@ class AlgoliaEngine implements EngineInterface
         }
 
         return $result;
+    }
+
+    protected function doClear($indexName)
+    {
+        return [
+            $indexName => $this->algolia->initIndex($indexName)->clearIndex()
+        ];
+    }
+
+    protected function doDelete($indexName)
+    {
+        return [
+            $indexName => $this->algolia->deleteIndex($indexName)
+        ];
     }
 }

--- a/src/Engine/AlgoliaEngine.php
+++ b/src/Engine/AlgoliaEngine.php
@@ -46,7 +46,7 @@ class AlgoliaEngine implements EngineInterface
             ];
         }
 
-        return $this->batchDelete($searchableEntities);
+        return $this->batchRemove($searchableEntities);
     }
 
     public function clear($indexName)
@@ -116,7 +116,7 @@ class AlgoliaEngine implements EngineInterface
         return $result;
     }
 
-    private function batchDelete($searchableEntities)
+    private function batchRemove($searchableEntities)
     {
         $data = [];
         foreach ($searchableEntities as $entity) {

--- a/src/Engine/AlgoliaEngine.php
+++ b/src/Engine/AlgoliaEngine.php
@@ -22,14 +22,16 @@ class AlgoliaEngine implements EngineInterface
 
     public function update($searchableEntities)
     {
+        $batch = $this->doUpdate($searchableEntities);
 
-        return $this->batchUpdate($searchableEntities);
+        return $this->formatIndexingResponse($batch);
     }
 
     public function remove($searchableEntities)
     {
+        $batch = $this->doRemove($searchableEntities);
 
-        return $this->batchRemove($searchableEntities);
+        return $this->formatIndexingResponse($batch);
     }
 
     public function clear($indexName)
@@ -78,7 +80,7 @@ class AlgoliaEngine implements EngineInterface
         return (int) $results['nbHits'];
     }
 
-    protected function batchUpdate($searchableEntities)
+    protected function doUpdate($searchableEntities)
     {
         if ($searchableEntities instanceof SearchableEntityInterface) {
             $searchableEntities = [$searchableEntities];
@@ -111,7 +113,7 @@ class AlgoliaEngine implements EngineInterface
         return $result;
     }
 
-    protected function batchRemove($searchableEntities)
+    protected function doRemove($searchableEntities)
     {
         if ($searchableEntities instanceof SearchableEntityInterface) {
             $searchableEntities = [$searchableEntities];
@@ -153,5 +155,15 @@ class AlgoliaEngine implements EngineInterface
         return [
             $indexName => $this->algolia->deleteIndex($indexName)
         ];
+    }
+
+    protected function formatIndexingResponse($batch)
+    {
+        $response = [];
+        foreach ($batch as $indexName => $res) {
+            $response[$indexName] = count($res['objectIDs']);
+        }
+
+        return $response;
     }
 }

--- a/src/Engine/AlgoliaEngine.php
+++ b/src/Engine/AlgoliaEngine.php
@@ -95,7 +95,7 @@ class AlgoliaEngine implements EngineInterface
         return (int) $results['nbHits'];
     }
 
-    private function batchUpdate($searchableEntities)
+    protected function batchUpdate($searchableEntities)
     {
         $data = [];
         foreach ($searchableEntities as $entity) {
@@ -124,7 +124,7 @@ class AlgoliaEngine implements EngineInterface
         return $result;
     }
 
-    private function batchRemove($searchableEntities)
+    protected function batchRemove($searchableEntities)
     {
         $data = [];
         foreach ($searchableEntities as $entity) {

--- a/src/Engine/AlgoliaEngine.php
+++ b/src/Engine/AlgoliaEngine.php
@@ -22,29 +22,12 @@ class AlgoliaEngine implements EngineInterface
 
     public function update($searchableEntities)
     {
-        if (
-            $searchableEntities instanceof SearchableEntityInterface
-            && !empty($record = $searchableEntities->getSearchableArray())
-        ) {
-            return [
-                $searchableEntities->getIndexName() => $this->algolia
-                    ->initIndex($searchableEntities->getIndexName())
-                    ->addObject($record, $searchableEntities->getId())
-            ];
-        }
 
         return $this->batchUpdate($searchableEntities);
     }
 
     public function remove($searchableEntities)
     {
-        if ($searchableEntities instanceof SearchableEntityInterface) {
-            return [
-                $searchableEntities->getIndexName() => $this->algolia
-                    ->initIndex($searchableEntities->getIndexName())
-                    ->deleteObject($searchableEntities->getId())
-            ];
-        }
 
         return $this->batchRemove($searchableEntities);
     }
@@ -97,6 +80,10 @@ class AlgoliaEngine implements EngineInterface
 
     protected function batchUpdate($searchableEntities)
     {
+        if ($searchableEntities instanceof SearchableEntityInterface) {
+            $searchableEntities = [$searchableEntities];
+        }
+
         $data = [];
         foreach ($searchableEntities as $entity) {
             if (empty($entity->getSearchableArray())) {
@@ -126,6 +113,10 @@ class AlgoliaEngine implements EngineInterface
 
     protected function batchRemove($searchableEntities)
     {
+        if ($searchableEntities instanceof SearchableEntityInterface) {
+            $searchableEntities = [$searchableEntities];
+        }
+
         $data = [];
         foreach ($searchableEntities as $entity) {
             if (empty($entity->getSearchableArray())) {

--- a/tests/AlgoliaSearch/AlgoliaEngineTest.php
+++ b/tests/AlgoliaSearch/AlgoliaEngineTest.php
@@ -14,15 +14,15 @@ class AlgoliaEngineTest extends BaseTest
         // Indexing
         $result = $engine->add($searchablePost);
         $this->assertArrayHasKey($searchablePost->getIndexName(), $result);
-        $this->assertArrayHasKey('taskID', $result[$searchablePost->getIndexName()]);
+        $this->assertEquals(1, $result[$searchablePost->getIndexName()]);
 
         $result = $engine->remove($searchablePost);
         $this->assertArrayHasKey($searchablePost->getIndexName(), $result);
-        $this->assertArrayHasKey('taskID', $result[$searchablePost->getIndexName()]);
+        $this->assertEquals(1, $result[$searchablePost->getIndexName()]);
 
         $result = $engine->update($searchablePost);
         $this->assertArrayHasKey($searchablePost->getIndexName(), $result);
-        $this->assertArrayHasKey('taskID', $result[$searchablePost->getIndexName()]);
+        $this->assertEquals(1, $result[$searchablePost->getIndexName()]);
 
         // Search
         $result = $engine->search('query', $searchablePost->getIndexName());
@@ -40,12 +40,10 @@ class AlgoliaEngineTest extends BaseTest
 
         // Cleanup
         $result = $engine->clear($searchablePost->getIndexName());
-        $this->assertArrayHasKey($searchablePost->getIndexName(), $result);
-        $this->assertArrayHasKey('taskID', $result[$searchablePost->getIndexName()]);
+        $this->assertTrue($result);
 
         // Delete index
         $result = $engine->delete($searchablePost->getIndexName());
-        $this->assertArrayHasKey($searchablePost->getIndexName(), $result);
-        $this->assertArrayHasKey('taskID', $result[$searchablePost->getIndexName()]);
+        $this->assertTrue($result);
     }
 }

--- a/tests/Engine/AlgoliaSyncEngine.php
+++ b/tests/Engine/AlgoliaSyncEngine.php
@@ -7,45 +7,58 @@ class AlgoliaSyncEngine extends AlgoliaEngine
 {
     public function add($searchableEntities)
     {
-        $res = parent::add($searchableEntities);
-
-        foreach ($res as $indexName => $response) {
-            $this->algolia->initIndex($indexName)->waitTask($response['taskID']);
-        }
-
-        return $res;
+        return $this->update($searchableEntities);
     }
 
     public function update($searchableEntities)
     {
-        $res = parent::update($searchableEntities);
+        $batch = $this->doUpdate($searchableEntities);
 
-        foreach ($res as $indexName => $response) {
+        foreach ($batch as $indexName => $response) {
             $this->algolia->initIndex($indexName)->waitTask($response['taskID']);
         }
 
-        return $res;
+        return $this->formatIndexingResponse($batch);
     }
 
     public function remove($searchableEntities)
     {
-        $res = parent::remove($searchableEntities);
+        $batch = $this->doRemove($searchableEntities);
 
-        foreach ($res as $indexName => $response) {
+        foreach ($batch as $indexName => $response) {
             $this->algolia->initIndex($indexName)->waitTask($response['taskID']);
         }
 
-        return $res;
+        return $this->formatIndexingResponse($batch);
     }
 
     public function clear($indexName)
     {
-        $res = parent::clear($indexName);
+        try {
+            $batch = $this->doClear($indexName);
 
-        foreach ($res as $indexName => $response) {
-            $this->algolia->initIndex($indexName)->waitTask($response['taskID']);
+            foreach ($batch as $indexName => $response) {
+                $this->algolia->initIndex($indexName)->waitTask($response['taskID']);
+            }
+        } catch (\Exception $e) {
+            return false;
         }
 
-        return $res;
+        return true;
+    }
+
+    public function delete($indexName)
+    {
+        try {
+            $batch = $this->doDelete($indexName);
+
+            foreach ($batch as $indexName => $response) {
+                $this->algolia->initIndex($indexName)->waitTask($response['taskID']);
+            }
+        } catch (\Exception $e) {
+            return false;
+        }
+
+        return true;
     }
 }


### PR DESCRIPTION
The last change before the final release. It fixes https://github.com/algolia/search-bundle/issues/154

I modified the type of data returned by the engine. Before the response from Algolia was returned like

```php
['index_name' => $response, 'index_name_2' => $response2]
```

For methods like `delete` and `clear` I changed the response to a boolean.
For methods like `add`, `update` and `remove` I changed the response to:

```php
['index_name' => (int) $numberOfAffectedRecords, 'index_name_2' => (int) $numberOfAffectedRecords2]
```

This allow you to know if some records you passed didn't get index. 

Example:

<img width="705" alt="1__sf-demo-app__bash_" src="https://user-images.githubusercontent.com/1525636/34768413-0b0793e8-f5fb-11e7-9da1-c13918115154.png">

  