### PR TITLE
Export settings to file without prefix in the index name

### DIFF
--- a/src/IndexManager.php
+++ b/src/IndexManager.php
@@ -223,8 +223,8 @@ class IndexManager implements IndexManagerInterface
         return $formattedResponse;
     }
 
-    private function removePrefixFromIndexName($fullIndexName)
+    private function removePrefixFromIndexName($indexName)
     {
-        return substr($fullIndexName, strlen($this->configuration['prefix']));
+        return preg_replace('/^'.preg_quote($this->configuration['prefix'], '/').'/', '', $indexName);
     }
 }

--- a/src/Settings/AlgoliaSettingsManager.php
+++ b/src/Settings/AlgoliaSettingsManager.php
@@ -75,6 +75,13 @@ class AlgoliaSettingsManager implements SettingsManagerInterface
 
     private function getFileName($indexName, $type)
     {
+        $indexName = $this->removePrefixFromIndexName($indexName);
+
         return sprintf('%s/%s-%s.json', $this->config['settingsDirectory'], $indexName, $type);
+    }
+
+    private function removePrefixFromIndexName($indexName)
+    {
+        return preg_replace('/^'.preg_quote($this->config['prefix'], '/').'/', '', $indexName);
     }
 }

--- a/tests/AlgoliaSearch/SettingsTest.php
+++ b/tests/AlgoliaSearch/SettingsTest.php
@@ -47,10 +47,10 @@ class SettingsTest extends BaseTest
         $message = $this->settingsManager->backup(['indices' => ['posts']]);
 
         $this->assertContains('Saved settings for', $message[0]);
-        $this->assertTrue(file_exists($this->settingsDir.'/TRAVIS_sf_settings_posts-settings.json'));
+        $this->assertTrue(file_exists($this->settingsDir.'/posts-settings.json'));
 
         $savedSettings = json_decode(file_get_contents(
-            $this->settingsDir.'/TRAVIS_sf_settings_posts-settings.json'
+            $this->settingsDir.'/posts-settings.json'
         ), true);
 
         $this->assertArraySubset($settingsToUpdate, $savedSettings);
@@ -74,7 +74,7 @@ class SettingsTest extends BaseTest
         $this->assertContains('Pushed settings for', $message[0]);
 
         $savedSettings = json_decode(file_get_contents(
-            $this->settingsDir.'/TRAVIS_sf_settings_posts-settings.json'
+            $this->settingsDir.'/posts-settings.json'
         ), true);
 
         for ($i=0;$i<5;$i++) {


### PR DESCRIPTION
I believe it's best. Otherwise, when you're exporting to dev settings, you can push them on prod or staging.