### PR TITLE
bug(search:import command): Multiple entity managers support

### DIFF
--- a/src/Command/SearchImportCommand.php
+++ b/src/Command/SearchImportCommand.php
@@ -31,8 +31,8 @@ class SearchImportCommand extends IndexCommand
         $config = $this->indexManager->getConfiguration();
 
         foreach ($entitiesToIndex as $indexName => $entityClassName) {
-            $repository = $doctrine->getRepository($entityClassName);
-            $manager = $doctrine->getManager();
+            $manager = $doctrine->getManagerForClass($entityClassName);
+            $repository = $manager->getRepository($entityClassName);
 
             $entities = $repository->findAll();
 


### PR DESCRIPTION
Retrieve the correct object manager for the given entity instead of the default one to prevent errors like : 
 The class 'MyAwesomeBundle\Entity\User' was not found in the chain configured namespaces MyDefaultBundle\Entity