### PR TITLE
Custom ObjectID content

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,23 @@ algolia_search:
 
 Checkout the [indexing documentation](https://www.algolia.com/doc/api-client/symfony/indexing/) to learn how to send data to Algolia.
 
+
+#### object_id
+
+By default, the bundle populates ObjectID index retrieving ids from entities metadata.
+But you could totally use a different property of your entity to do that. So you can
+provide in your configuration the getter which will be used to populate the ObjectID
+index in Algolia.
+
+Example:
+```yaml
+algolia_search:
+  indices:
+    - name: posts
+      class: App\Entity\Post
+      object_id: getSlug
+```
+
 ## Per environment setup
 
 Usually, you need different configurations per environment, at least to avoid

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -47,6 +47,11 @@ class Configuration implements ConfigurationInterface
                                 ->info('When set to true, it will call normalize method with an extra groups parameter "groups" => [Searchable::NORMALIZATION_GROUP]')
                                 ->defaultFalse()
                             ->end()
+                            ->scalarNode('object_id')
+                                ->info('When set, it will search the given getter in the class')
+                                ->cannotBeEmpty()
+                                ->defaultNull()
+                            ->end()
                         ->end()
                     ->end()
                 ->end() // indices

--- a/src/IndexManager.php
+++ b/src/IndexManager.php
@@ -17,6 +17,7 @@ class IndexManager implements IndexManagerInterface
     private $searchableEntities;
     private $classToIndexMapping;
     private $classToSerializerGroupMapping;
+    private $objectIDGetters;
     private $normalizer;
 
     public function __construct(NormalizerInterface $normalizer, EngineInterface $engine, array $configuration)
@@ -28,6 +29,7 @@ class IndexManager implements IndexManagerInterface
         $this->setSearchableEntities();
         $this->setClassToIndexMapping();
         $this->setClassToSerializerGroupMapping();
+        $this->setObjectIDGetters();
     }
 
     public function isSearchable($className)
@@ -68,7 +70,10 @@ class IndexManager implements IndexManagerInterface
                     $entity,
                     $objectManager->getClassMetadata($className),
                     $this->normalizer,
-                    ['useSerializerGroup' => $this->canUseSerializerGroup($className)]
+                    [
+                        'useSerializerGroup' => $this->canUseSerializerGroup($className),
+                        'objectID' => $this->retrieveObjectIDGetter($className),
+                    ]
                 );
             }
 
@@ -162,6 +167,11 @@ class IndexManager implements IndexManagerInterface
         return $this->classToSerializerGroupMapping[$className];
     }
 
+    private function retrieveObjectIDGetter($className)
+    {
+        return $this->objectIDGetters[$className];
+    }
+
     private function setClassToIndexMapping()
     {
         $mapping = [];
@@ -203,6 +213,14 @@ class IndexManager implements IndexManagerInterface
         }
 
         $this->classToSerializerGroupMapping = $mapping;
+    }
+
+    private function setObjectIDGetters()
+    {
+        $this->objectIDGetters = [];
+        foreach ($this->configuration['indices'] as $indexDetails) {
+            $this->objectIDGetters[$indexDetails['class']] = $indexDetails['object_id'];
+        }
     }
 
     private function formatBatchResponse(array $batch)

--- a/tests/AlgoliaSearch/ConfigurationTest.php
+++ b/tests/AlgoliaSearch/ConfigurationTest.php
@@ -64,11 +64,13 @@ class ConfigurationTest extends BaseTest
                     "indices" => [
                         'posts' => [
                             'class' => 'App\Entity\Post',
-                            'enable_serializer_groups' => false
+                            'enable_serializer_groups' => false,
+                            'object_id' => null,
                         ],
                         'tags' => [
                             'class' => 'App\Entity\Tag',
-                            'enable_serializer_groups' => true
+                            'enable_serializer_groups' => true,
+                            'object_id' => null,
                         ],
                     ],
                 ]

--- a/tests/AlgoliaSearch/SerializationTest.php
+++ b/tests/AlgoliaSearch/SerializationTest.php
@@ -39,6 +39,7 @@ class SerializationTest extends BaseTest
         $post = new Post([
             'id' => 12,
             'title' => 'a simple post',
+            'slug' => 'a-simple-post',
             'content' => 'some text',
             'publishedAt' => $datetime,
             'comments' => [new Comment([
@@ -58,6 +59,7 @@ class SerializationTest extends BaseTest
         $expected = [
             "id" => 12,
             "title" => "a simple post",
+            "slug" => "a-simple-post",
             "content" => "some text",
             "publishedAt" => $serializedDateTime,
             "comments" => [
@@ -84,6 +86,7 @@ class SerializationTest extends BaseTest
         $post = new Post([
             'id' => 12,
             'title' => 'a simple post',
+            'slug' => 'a-simple-post',
             'content' => 'some text',
             'publishedAt' => $datetime,
             'comments' => [new Comment([
@@ -105,6 +108,7 @@ class SerializationTest extends BaseTest
             "id" => 12,
             "title" => "a simple post",
             "publishedAt" => $serializedDateTime,
+            "slug" => "a-simple-post",
         ];
 
         $this->assertEquals($expected, $searchablePost->getSearchableArray());

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -38,9 +38,11 @@ class BaseTest extends TestCase
     {
         $post = new Post;
         $post->setTitle('Test');
+        $post->setSlug('test');
         $post->setContent('Test content');
 
         if (!is_null($id)) {
+            $post->setSlug('test-'.$id);
             $post->setId($id);
         }
 

--- a/tests/Entity/Post.php
+++ b/tests/Entity/Post.php
@@ -37,6 +37,13 @@ class Post
     /**
      * @var string
      *
+     * @ORM\Column(type="string")
+     */
+    private $slug;
+
+    /**
+     * @var string
+     *
      * @ORM\Column(type="text")
      */
     private $content;
@@ -63,6 +70,7 @@ class Post
     public function __construct(array $attributes = [])
     {
         $this->id = isset($attributes['id']) ? $attributes['id'] : null;
+        $this->slug = isset($attributes['slug']) ? $attributes['slug'] : null;
         $this->title = isset($attributes['title']) ? $attributes['title'] : null;
         $this->content = isset($attributes['content']) ? $attributes['content'] : null;
         $this->publishedAt = isset($attributes['publishedAt']) ? $attributes['publishedAt'] : new \DateTime();
@@ -90,6 +98,19 @@ class Post
     public function setTitle($title)
     {
         $this->title = $title;
+    }
+
+    /**
+     * @Groups({"searchable"})
+     */
+    public function getSlug()
+    {
+        return $this->slug;
+    }
+
+    public function setSlug($slug)
+    {
+        return $this->slug = $slug;
     }
 
     public function getContent()

--- a/tests/config/default.php
+++ b/tests/config/default.php
@@ -7,10 +7,12 @@ return [
         'posts' => [
             'class' => 'Algolia\SearchBundle\Entity\Post',
             'enable_serializer_groups' => false,
+            'object_id' => 'getSlug',
         ],
         'comments' => [
             'class' => 'Algolia\SearchBundle\Entity\Comment',
             'enable_serializer_groups' => false,
+            'object_id' => null,
         ],
     ]
 ];


### PR DESCRIPTION
Allow to use a getter instead of doctrine ids to populate ObjectID property on Algolia.

No BC changes, it allows to make something like :
```
algolia_search:
    indices:
        - name: posts
          class: App\Entity\Post
          object_id: getSlug
```