### PR TITLE
Detect if Sf3 project use new dir structure

### DIFF
--- a/src/DependencyInjection/AlgoliaSearchExtension.php
+++ b/src/DependencyInjection/AlgoliaSearchExtension.php
@@ -34,16 +34,17 @@ class AlgoliaSearchExtension extends Extension
             $config['prefix'] = $container->getParameter("kernel.environment").'_';
         }
 
+        $rootDir = $container->getParameterBag()->get('kernel.project_dir');
+
         if (is_null($config['settingsDirectory'])) {
-            if (3 == Kernel::MAJOR_VERSION) {
+            if (3 == Kernel::MAJOR_VERSION && !is_dir($rootDir.'/config/')) {
                 $config['settingsDirectory'] = '/app/Resources/SearchBundle/settings/';
             } else {
                 $config['settingsDirectory'] = '/config/settings/algolia_search/';
             }
         }
 
-        $root = $container->getParameterBag()->get('kernel.project_dir');
-        $config['settingsDirectory'] = $root.$config['settingsDirectory'];
+        $config['settingsDirectory'] = $rootDir.$config['settingsDirectory'];
 
         $container->setParameter('algolia_search.doctrineSubscribedEvents', $config['doctrineSubscribedEvents']);
 


### PR DESCRIPTION
 Fix #207 

If the project is using Sf 3, we check of the `/config/` folder exists. As far as I understand, this directory only exists with the new project structure.