### PR TITLE
 Index entity conditionally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ CHANGELOG
 
     Add new `index_if` configuration key for indices.
     This should be the path to a property in the entity which
-    evaluates to true if the item should be index (false to bypass indexing).
+    evaluates to true if the item should be indexed and false to 
+    bypass indexing or remove existing object from the index.
 
     Example:
         - indices:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,21 @@ CHANGELOG
 3.1.0
 -----
 
-- Introduce `batchSize` config key (default: 500) - PR [#208](https://github.com/algolia/search-bundle/pull/203)
+* Introduce `batchSize` config key (default: 500) - PR [#208](https://github.com/algolia/search-bundle/pull/203)
     
     This config allow you create smaller or bigger batch calls to Algolia. The same config is used by doctrine in the ImportCommand.
     
+* Feature: Index entities conditionally (using a dedicated method)
+
+    Add new `index_if` configuration key for indices.
+    This should be the name of a method in the entity that
+    returns true if the item should be index (false to bypass indexing).
+
+    Example:
+        - indices:
+            - name: posts
+              class: App\Entity\Post
+              index_if: isPublished
 
 2.2.0
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ CHANGELOG
 * Feature: Index entities conditionally (using a dedicated method)
 
     Add new `index_if` configuration key for indices.
-    This should be the name of a method in the entity that
-    returns true if the item should be index (false to bypass indexing).
+    This should be the path to a property in the entity which
+    evaluates to true if the item should be index (false to bypass indexing).
 
     Example:
         - indices:

--- a/src/Command/SearchImportCommand.php
+++ b/src/Command/SearchImportCommand.php
@@ -46,7 +46,7 @@ class SearchImportCommand extends IndexCommand
 
                 $output->writeln(sprintf(
                     'Indexed <comment>%s / %s</comment> %s entities into %s index',
-                    $response[$indexName],
+                    isset($response[$indexName]) ? $response[$indexName] : 0,
                     count($entities),
                     $entityClassName,
                     '<info>' . $config['prefix'] . $indexName . '</info>'
@@ -55,9 +55,10 @@ class SearchImportCommand extends IndexCommand
                 $page++;
                 $repository->clear();
             } while (count($entities) >= $config['batchSize']);
+
+            $repository->clear();
         }
 
-        $repository->clear();
 
         $output->writeln('<info>Done!</info>');
     }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -51,7 +51,7 @@ class Configuration implements ConfigurationInterface
                                 ->defaultFalse()
                             ->end()
                             ->scalarNode('index_if')
-                                ->info('Name of the method in the entity used to decide if an entry should be indexed or not.')
+                                ->info('Property accessor path (like method or property name) used to decide if an entry should be indexed.')
                                 ->defaultNull()
                             ->end()
                         ->end()

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -50,6 +50,10 @@ class Configuration implements ConfigurationInterface
                                 ->info('When set to true, it will call normalize method with an extra groups parameter "groups" => [Searchable::NORMALIZATION_GROUP]')
                                 ->defaultFalse()
                             ->end()
+                            ->scalarNode('index_if')
+                                ->info('Name of the method in the entity used to decide if an entry should be indexed or not.')
+                                ->defaultNull()
+                            ->end()
                         ->end()
                     ->end()
                 ->end() // indices

--- a/src/EventListener/SearchIndexerSubscriber.php
+++ b/src/EventListener/SearchIndexerSubscriber.php
@@ -25,20 +25,30 @@ class SearchIndexerSubscriber implements EventSubscriber
 
     public function postUpdate(LifecycleEventArgs $args)
     {
-        $this->index($args);
+        $object = $args->getObject();
+        $objectManager = $args->getObjectManager();
+
+        if (!$this->indexManager->isSearchable($object)) {
+            return;
+        }
+
+        if ($this->indexManager->shouldBeIndexed($object)) {
+            $this->indexManager->index($object, $objectManager);
+        } else {
+            $this->indexManager->remove($object, $objectManager);
+        }
     }
 
     public function postPersist(LifecycleEventArgs $args)
     {
-        $this->index($args);
-    }
-
-    public function index(LifecycleEventArgs $args)
-    {
         $object = $args->getObject();
         $objectManager = $args->getObjectManager();
 
-        if ($this->indexManager->isSearchable($object)) {
+        if (!$this->indexManager->isSearchable($object)) {
+            return;
+        }
+
+        if ($this->indexManager->shouldBeIndexed($object)) {
             $this->indexManager->index($object, $objectManager);
         }
     }

--- a/src/IndexManager.php
+++ b/src/IndexManager.php
@@ -67,7 +67,7 @@ class IndexManager implements IndexManagerInterface
                 $className = ClassUtils::getClass($entity);
                 $this->assertIsSearchable($className);
 
-                if (!$this->shouldBeIndexed($className, $entity)) {
+                if (!$this->shouldBeIndexed($entity)) {
                     continue;
                 }
 
@@ -165,8 +165,9 @@ class IndexManager implements IndexManagerInterface
         return $this->engine->count($query, $this->getFullIndexName($className));
     }
 
-    protected function shouldBeIndexed($className, &$entity)
+    public function shouldBeIndexed($entity)
     {
+        $className = ClassUtils::getClass($entity);
 
         if ($propertyPath = $this->indexIfMapping[$className]) {
             if ($this->propertyAccessor->isReadable($entity, $propertyPath)) {

--- a/src/IndexManager.php
+++ b/src/IndexManager.php
@@ -172,6 +172,8 @@ class IndexManager implements IndexManagerInterface
             if ($this->propertyAccessor->isReadable($entity, $propertyPath)) {
                 return (bool) $this->propertyAccessor->getValue($entity, $propertyPath);
             }
+
+            return false;
         }
 
         return true;

--- a/tests/AlgoliaSearch/ConfigurationTest.php
+++ b/tests/AlgoliaSearch/ConfigurationTest.php
@@ -56,8 +56,8 @@ class ConfigurationTest extends BaseTest
                 [
                     "prefix" => "sf_",
                     "indices" => [
-                        ['name' => 'posts', 'class' => 'App\Entity\Post'],
-                        ['name' => 'tags', 'class' => 'App\Entity\Tag', 'enable_serializer_groups' => true],
+                        ['name' => 'posts', 'class' => 'App\Entity\Post', 'index_if' => null],
+                        ['name' => 'tags', 'class' => 'App\Entity\Tag', 'enable_serializer_groups' => true, 'index_if' => null],
                     ],
                 ],[
                     "prefix" => "sf_",
@@ -68,11 +68,13 @@ class ConfigurationTest extends BaseTest
                     "indices" => [
                         'posts' => [
                             'class' => 'App\Entity\Post',
-                            'enable_serializer_groups' => false
+                            'enable_serializer_groups' => false,
+                            'index_if' => null,
                         ],
                         'tags' => [
                             'class' => 'App\Entity\Tag',
-                            'enable_serializer_groups' => true
+                            'enable_serializer_groups' => true,
+                            'index_if' => null,
                         ],
                     ],
                 ]

--- a/tests/config/default.php
+++ b/tests/config/default.php
@@ -8,10 +8,12 @@ return [
         'posts' => [
             'class' => 'Algolia\SearchBundle\Entity\Post',
             'enable_serializer_groups' => false,
+            'index_if' => null,
         ],
         'comments' => [
             'class' => 'Algolia\SearchBundle\Entity\Comment',
             'enable_serializer_groups' => false,
+            'index_if' => null,
         ],
     ]
 ];


### PR DESCRIPTION
Fix #202 

Add new `index_if` configuration key for indices.
This should be the name of a method in the entity that returns true if the item should be index (false to bypass indexing).