### PR TITLE
Lazy-load commands

### DIFF
--- a/src/Command/SearchClearCommand.php
+++ b/src/Command/SearchClearCommand.php
@@ -10,10 +10,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class SearchClearCommand extends IndexCommand
 {
+    protected static $defaultName = 'search:clear';
+
     protected function configure()
     {
         $this
-            ->setName('search:clear')
             ->setDescription('Clear index (remove all data but keep index and settings)')
             ->addOption('indices', 'i', InputOption::VALUE_OPTIONAL, 'Comma-separated list of index names')
             ->addArgument(

--- a/src/Command/SearchImportCommand.php
+++ b/src/Command/SearchImportCommand.php
@@ -10,10 +10,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class SearchImportCommand extends IndexCommand
 {
+    protected static $defaultName = 'search:import';
+
     protected function configure()
     {
         $this
-            ->setName('search:import')
             ->setDescription('Import given entity into search engine')
             ->addOption('indices', 'i', InputOption::VALUE_OPTIONAL, 'Comma-separated list of index names')
             ->addArgument(

--- a/src/Command/SearchSettingsBackupCommand.php
+++ b/src/Command/SearchSettingsBackupCommand.php
@@ -2,16 +2,16 @@
 
 namespace Algolia\SearchBundle\Command;
 
-use Algolia\SearchBundle\Settings\SettingsManagerInterface;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 
 class SearchSettingsBackupCommand extends SearchSettingsCommand
 {
+    protected static $defaultName = 'search:settings:backup';
+
     protected function configure()
     {
         $this
-            ->setName('search:settings:backup')
             ->setDescription('Backup search engine settings into your project')
             ->addOption('indices', 'i', InputOption::VALUE_OPTIONAL, 'Comma-separated list of index names')
             ->addArgument(

--- a/src/Command/SearchSettingsPushCommand.php
+++ b/src/Command/SearchSettingsPushCommand.php
@@ -2,16 +2,16 @@
 
 namespace Algolia\SearchBundle\Command;
 
-use Algolia\SearchBundle\Settings\SettingsManagerInterface;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 
 class SearchSettingsPushCommand extends SearchSettingsCommand
 {
+    protected static $defaultName = 'search:settings:push';
+
     protected function configure()
     {
         $this
-            ->setName('search:settings:push')
             ->setDescription('Push settings from your project to the search engine')
             ->addOption('indices', 'i', InputOption::VALUE_OPTIONAL, 'Comma-separated list of index names')
             ->addArgument(

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -6,9 +6,7 @@
 
     <services>
 
-        <prototype namespace="Algolia\SearchBundle\Command\" resource="../../Command" autowire="true">
-            <tag name="console.command" />
-        </prototype>
+        <prototype namespace="Algolia\SearchBundle\Command\" resource="../../Command" autowire="true" autoconfigure="true" />
 
         <service id="search.search_indexer_subscriber" class="Algolia\SearchBundle\EventListener\SearchIndexerSubscriber" public="true">
             <argument type="service" id="search.index_manager" />


### PR DESCRIPTION
so the algolia client isn't instantiated uselessly or too soon.

Some refs: 

- https://symfony.com/blog/new-in-symfony-3-4-lazy-commands
- https://github.com/symfony/symfony/pull/23887

---

The `algolia_client` needs the `ALGOLIA_APP_ID` & `ALGOLIA_API_KEY` env vars. But when building & releasing my application, this vars are not necessarily set (they are only set and available on the server, hence once the release is deployed). Each of these commands need the index or settings managers, which in turn require the client as dependency. Which means you'll get a:

> Environment variable not found: "ALGOLIA_APP_ID".

by running any command registered in the application.
By lazy-loading the algolia commands, none of their dependencies are instantiated unless really required.