### PR TITLE
Remove doctrine event subscriber when not used

### DIFF
--- a/src/DependencyInjection/AlgoliaSearchExtension.php
+++ b/src/DependencyInjection/AlgoliaSearchExtension.php
@@ -46,7 +46,11 @@ class AlgoliaSearchExtension extends Extension
 
         $config['settingsDirectory'] = $rootDir.$config['settingsDirectory'];
 
-        $container->setParameter('algolia_search.doctrineSubscribedEvents', $config['doctrineSubscribedEvents']);
+        if (count($doctrineSubscribedEvents = $config['doctrineSubscribedEvents']) > 0) {
+            $container->getDefinition('search.search_indexer_subscriber')->setArgument(1, $doctrineSubscribedEvents);
+        } else {
+            $container->removeDefinition('search.search_indexer_subscriber');
+        }
 
         $indexManagerDefinition = (new Definition(
             IndexManager::class,

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -12,7 +12,7 @@
 
         <service id="search.search_indexer_subscriber" class="Algolia\SearchBundle\EventListener\SearchIndexerSubscriber" public="true">
             <argument type="service" id="search.index_manager" />
-            <argument key="$subscribedEvents">%algolia_search.doctrineSubscribedEvents%</argument>
+            <argument type="collection" /> <!-- doctrine subscribed events -->
             <tag name="doctrine.event_subscriber" connection="default" />
             <tag name="doctrine_mongodb.odm.event_subscriber" connection="default" />
         </service>


### PR DESCRIPTION
Same as in https://github.com/algolia/search-bundle/pull/218: despite I'm not subscribing to doctrine events right now, accessing the entity manager will instantiate the client uselessly. So removing the subscriber when configured explicitly to not listen anything makes sense.

Also the parameter `algolia_search.doctrineSubscribedEvents` isn't really useful and isn't the common practice to set service definition arguments based on configuration (the parameter will remains accessible on userland).