### PR TITLE
Introduce php-cs-fixer with config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor/
 /tests/cache/
 /composer.lock
+.php_cs.cache

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,0 +1,15 @@
+<?php
+
+$finder = PhpCsFixer\Finder::create()
+    ->in(__DIR__.'/src')
+    ->in(__DIR__.'/tests')
+;
+
+return PhpCsFixer\Config::create()
+    ->setUsingCache(true)
+    ->setRules([
+        '@Symfony' => true,
+        'array_syntax' => ['syntax' => 'short'],
+    ])
+    ->setFinder($finder)
+;

--- a/composer.json
+++ b/composer.json
@@ -36,12 +36,17 @@
         "phpunit/phpunit": "^5.7 || ^6.5",
         "symfony/doctrine-bridge": "^3.4.0 || ^4.0.0",
         "symfony/framework-bundle": "^3.4.0 || ^4.0.0",
-        "symfony/yaml": "^3.4.0 || ^4.0.0"
+        "symfony/yaml": "^3.4.0 || ^4.0.0",
+        "friendsofphp/php-cs-fixer": "^2.11"
     },
     "extra": {
         "branch-alias": {
             "dev-master": "3.0.x-dev"
         }
+    },
+    "scripts": {
+        "lint": "php-cs-fixer fix src --dry-run --diff",
+        "lint:fix": "php-cs-fixer fix src"
     },
     "sort-packages": true
 }


### PR DESCRIPTION
Based on the work started by https://github.com/algolia/search-bundle/pull/179

I added a simple configuration, I'd rather avoid fancy rules. I think the `@Symfony` is already a good ruleset, I only added the array short syntax.

I will fix the code once we agreed on the config (easier in case we need to rebase).