### PR TITLE
Fix Travis build

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true" bootstrap="vendor/autoload.php">
+<phpunit colors="true" bootstrap="vendor/autoload.php" convertDeprecationsToExceptions="false">
     <php>
         <env name="KERNEL_CLASS" value="Algolia\SearchBundle\Kernel" />
         <env name="APP_ENV" value="test" />
         <env name="APP_DEBUG" value="false" />
-        <env name="ALGOLIA_PREFIX" value="TRAVIS_sf_" />
+        <env name="ALGOLIA_PREFIX" value="sf_phpunit_" />
+        <env name="TRAVIS_JOB_NUMBER" value="" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled" />
     </php>
     <testsuites>
         <testsuite name="TestCase">

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -2,19 +2,26 @@
 
 namespace Algolia\SearchBundle;
 
-use Algolia\SearchBundle\Doctrine\NullConnection;
-use Algolia\SearchBundle\Engine\AlgoliaEngine;
-use Algolia\SearchBundle\Engine\AlgoliaSyncEngine;
-use Algolia\SearchBundle\Engine\NullEngine;
 use Algolia\SearchBundle\Entity\Comment;
-use AlgoliaSearch\Client;
 use Algolia\SearchBundle\Entity\Post;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
-use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
-use Symfony\Component\Yaml\Yaml;
 
 class BaseTest extends KernelTestCase
 {
+    public static function setUpBeforeClass()
+    {
+        /*
+         * Older version of PHPUnit (<6.0) load
+         * env variables differently, we override them
+         * here to make sure they're coming from the
+         * env rather than the XML config
+         */
+        if (class_exists('\PHPUnit_Runner_Version')) {
+            $_ENV['ALGOLIA_PREFIX'] = getenv('ALGOLIA_PREFIX');
+            $_ENV['TRAVIS_JOB_NUMBER'] = getenv('TRAVIS_JOB_NUMBER');
+        }
+    }
+
     public function setUp()
     {
         $this->bootKernel();
@@ -60,7 +67,7 @@ class BaseTest extends KernelTestCase
 
     protected function getPrefix()
     {
-        return getenv('ALGOLIA_PREFIX');
+        return $this->get('search.index_manager')->getConfiguration()['prefix'];
     }
 
     protected function get($id)

--- a/tests/TestCase/AlgoliaEngineTest.php
+++ b/tests/TestCase/AlgoliaEngineTest.php
@@ -4,6 +4,19 @@ namespace Algolia\SearchBundle;
 
 class AlgoliaEngineTest extends BaseTest
 {
+    /**
+     *
+     * Doctrine is currently splitting the common package
+     * into 3 separate ones, some deprecation notice appeared
+     * until we can migrate doctrine/common and keep BC
+     * with PHP 5.6 and Symfony 3.4, we allow deprecation
+     * notice for this test
+     *
+     * https://github.com/doctrine/common/issues/826
+     *
+     * @group legacy
+     *
+     */
     public function testIndexing()
     {
         $engine = $this->get('search.engine');

--- a/tests/config/algolia_search.yml
+++ b/tests/config/algolia_search.yml
@@ -1,5 +1,5 @@
 algolia_search:
-    prefix: '%env(ALGOLIA_PREFIX)%'
+    prefix: '%env(ALGOLIA_PREFIX)%%env(TRAVIS_JOB_NUMBER)%_'
     nbResults: 12
     batchSize: 100
     settingsDirectory: '/tests/cache/settings'


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | Fix #...  <!-- will close issue automatically, if any -->
| Need Doc update   | no


## Describe your change

First, Travis wasn't using a different prefix for each build, so all test where using the same indices. Of course, everything failed. I think it's because before, I limited concurrent build to 1, but I probably changed it later and didn't realize it broke.

With PHPUnit < 6, environment variables are not set properly in `$_ENV` for some obscure reason, so I override them in `setUp`.

Doctrine is currently splitting the common package into 3 separate ones, some deprecation notice appeared until we can migrate doctrine/common and keep BC with PHP 5.6 and Symfony 3.4, we allow deprecation notice in PHPUnit.
https://github.com/doctrine/common/issues/826

Note: We could remove tests on 7.0 and 7.1 🤔 

## What problem is this fixing?

Fix the Travis build 🎉 
