### PR TITLE
Make AlgoliaClient lazy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 CHANGELOG
 =========
 
+UNRELEASED
+----------
+
+* Make Algolia Client lazy - PR [#251](https://github.com/algolia/search-bundle/pull/251)
+    
+    If you didn't set the `ALGOLIA_APP_ID` and `ALGOLIA_API_KEY` env variables
+    you will only get an error message when the client is used (a method is called),
+    not when its injected and not used.
+    
+    Note: This requires that you install `ocramius/proxy-manager` and 
+    `symfony/proxy-manager-bridge` packages 
+    
+    
+
 3.2.0
 ----------
 

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,9 @@
         "symfony/phpunit-bridge": "^3.4.0 || ^4.0",
         "symfony/yaml": "^3.4.0 || ^4.0.0",
         "friendsofphp/php-cs-fixer": "^2.11",
-        "jms/serializer-bundle": "^2.3"
+        "jms/serializer-bundle": "^2.3",
+        "ocramius/proxy-manager": "*",
+        "symfony/proxy-manager-bridge": "*"
     },
     "extra": {
         "branch-alias": {

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -15,7 +15,7 @@
             <tag name="doctrine_mongodb.odm.event_subscriber" connection="default" />
         </service>
 
-        <service id="algolia_client" class="AlgoliaSearch\Client" public="false">
+        <service id="algolia_client" class="AlgoliaSearch\Client" public="false" lazy="true">
             <argument key="$applicationID">%env(ALGOLIA_APP_ID)%</argument>
             <argument key="$apiKey">%env(ALGOLIA_API_KEY)%</argument>
         </service>

--- a/tests/TestCase/ClientProxyTest.php
+++ b/tests/TestCase/ClientProxyTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Algolia\SearchBundle\TestCase;
+
+use Algolia\SearchBundle\BaseTest;
+use ProxyManager\Proxy\ProxyInterface;
+
+class ClientProxyTest extends BaseTest
+{
+    private static $values = [];
+
+    public static function setUpBeforeClass()
+    {
+        // Unset env variables to make sure Algolia
+        // Credentials are only required when the
+        // client is used. Save them to restore them after.
+        // See: https://github.com/algolia/search-bundle/issues/241
+        self::$values = [
+            'env_id' => getenv('ALGOLIA_APP_ID'),
+            'env_key' => getenv('ALGOLIA_API_KEY'),
+            '_env' => $_ENV,
+            '_server' => $_SERVER,
+        ];
+
+        putenv('ALGOLIA_APP_ID');
+        putenv('ALGOLIA_API_KEY');
+        unset($_ENV['ALGOLIA_APP_ID']);
+        unset($_ENV['ALGOLIA_API_KEY']);
+        unset($_SERVER['ALGOLIA_APP_ID']);
+        unset($_SERVER['ALGOLIA_API_KEY']);
+    }
+
+    public static function tearDownAfterClass()
+    {
+
+        putenv('ALGOLIA_APP_ID='.self::$values['env_id']);
+        putenv('ALGOLIA_API_KEY='.self::$values['env_key']);
+        $_ENV = self::$values['_env'];
+        $_SERVER = self::$values['_server'];
+    }
+
+    public function testClientIsProxied()
+    {
+        $interfaces = class_implements($this->get('algolia.client'));
+
+        $this->assertTrue(in_array(ProxyInterface::class, $interfaces));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\EnvNotFoundException
+     */
+    public function testProxiedClientFailIfNoEnvVarsFound()
+    {
+        $this->get('algolia.client')->listIndexes();
+    }
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | yes    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | Fix #241   <!-- will close issue automatically, if any -->
| Need Doc update   | yes/no


## Describe your change

`algolia_client` service (API Client class) is now lazy.

## What problem is this fixing?

Avoid error message if Algolia env variables aren't defined when doing other operations, not related to Algolia (like emptying cache).

See #241, #199
