### PR TITLE
Use collection values only to avoid wrongly indexed data structures

### DIFF
--- a/Indexer/Indexer.php
+++ b/Indexer/Indexer.php
@@ -324,7 +324,7 @@ class Indexer
                 }
 
                 return $this->getFieldsForAlgolia($val, null, $depth + 1);
-            }, $value->toArray());
+            }, $value->getValues());
         }
 
         if (is_object($value) && $this->isEntity($this->objectManager, $value)) {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | -
| Need Doc update   | no


## Describe your change

This PR aims to ensure a collection is always indexed as an array. Under some circumstances it might happen that the keys of the collection are not correctly indexed PHP array's which will lead to objects in Algolia's search index instead of an array.