### PR TITLE
Adds phpstan for static analysis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,5 @@ before_script:
     - composer install
 
 script:
+    - ./vendor/bin/phpstan analyse src --level=1
     - eval $(./algolia-keys export) && ./vendor/bin/simple-phpunit -v

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,8 @@
         "friendsofphp/php-cs-fixer": "^2.11",
         "jms/serializer-bundle": "^2.3",
         "ocramius/proxy-manager": "*",
-        "symfony/proxy-manager-bridge": "*"
+        "symfony/proxy-manager-bridge": "*",
+        "phpstan/phpstan": "^0.10.3"
     },
     "extra": {
         "branch-alias": {

--- a/src/IndexManager.php
+++ b/src/IndexManager.php
@@ -11,6 +11,8 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class IndexManager implements IndexManagerInterface
 {
+    public $propertyAccessor;
+
     protected $engine;
     protected $configuration;
     protected $useSerializerGroups;


### PR DESCRIPTION
This PR proposes the addition of the package [Phpstan](https://github.com/phpstan/phpstan) as a dev dependency for **static analysis** purposes. If you are not familiar with static analysis or with Phpstan, you may want to check this article: [medium.com/@ondrejmirtes/phpstan-2939cd0ad0e3](https://medium.com/@ondrejmirtes/phpstan-2939cd0ad0e3).

**Note: There is no need for a release here.**

<img width="100%" alt="phpstan" src="https://user-images.githubusercontent.com/5457236/45117464-02f95a80-b156-11e8-9a94-4262c23b29ec.png">

It also modifies the `.travis.yml` file, in order to make sure that the newly introduced code on the bundle don't contains errors.

The level, for the moment, it's only `--level=1`. With time, we should try to reach the `--level=7` or `--level=max`.

**EDIT**: Phpstan requires php > 7.1. I need to find way of making travis pass for early versions of php.