### PR TITLE
Add $parameters args to IndexManager::count - fix #259

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ CHANGELOG
 UNRELEASED
 ----------
 
- * <Add new entries here>
+ * Fix bug in `IndexManager::count` to take parameters into account
+ 
+    Note that this bug fix is backward compatible but should be clean up
+    when we release a next major version.
 
 
 3.3.1

--- a/src/Engine/AlgoliaEngine.php
+++ b/src/Engine/AlgoliaEngine.php
@@ -73,9 +73,14 @@ class AlgoliaEngine implements EngineInterface
         return array_column($result['hits'], 'objectID');
     }
 
-    public function count($query, $indexName)
+    public function count($query, $indexName /*, array $parameters = [] */)
     {
-        $results = $this->algolia->initIndex($indexName)->search($query);
+        $parameters = [];
+        if (3 === func_num_args() && is_array(func_get_arg(2))) {
+            $parameters = func_get_arg(2);
+        }
+        
+        $results = $this->algolia->initIndex($indexName)->search($query, $parameters);
 
         return (int) $results['nbHits'];
     }

--- a/src/Engine/EngineInterface.php
+++ b/src/Engine/EngineInterface.php
@@ -18,5 +18,9 @@ interface EngineInterface
 
     public function searchIds($query, $indexName, $page = 0, $nbResults = null, array $parameters = []);
 
-    public function count($query, $indexName);
+    // TODO: Add $parameters argument
+    // The 3 arguments named $parameters will be added to this interface
+    // when we release the next major version
+    // See https://github.com/algolia/search-bundle/issues/259
+    public function count($query, $indexName /*, array $parameters = [] */);
 }

--- a/src/Engine/NullEngine.php
+++ b/src/Engine/NullEngine.php
@@ -41,7 +41,7 @@ class NullEngine implements EngineInterface
         return [];
     }
 
-    public function count($query, $indexName)
+    public function count($query, $indexName /*, array $parameters = [] */)
     {
         return 0;
     }

--- a/src/IndexManager.php
+++ b/src/IndexManager.php
@@ -163,7 +163,7 @@ class IndexManager implements IndexManagerInterface
     {
         $this->assertIsSearchable($className);
 
-        return $this->engine->count($query, $this->getFullIndexName($className));
+        return $this->engine->count($query, $this->getFullIndexName($className), $parameters);
     }
 
     public function shouldBeIndexed($entity)

--- a/tests/TestCase/AlgoliaEngineTest.php
+++ b/tests/TestCase/AlgoliaEngineTest.php
@@ -51,6 +51,8 @@ class AlgoliaEngineTest extends BaseTest
         $this->assertEquals(1, $result);
         $result = $engine->count('This should not have results', $searchablePost->getIndexName());
         $this->assertEquals(0, $result);
+        $result = $engine->count('', $searchablePost->getIndexName(), ['tagFilters' => 'test']);
+        $this->assertEquals(0, $result);
 
         // Cleanup
         $result = $engine->clear($searchablePost->getIndexName());


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | Fix #259   <!-- will close issue automatically, if any -->
| Need Doc update   | no


## Describe your change

The `$parameters` arg was forgotten when releasing the v3. It should have been handled from the begining. I'm using magic arguments to pass it anyway but this should be cleaned up when we release the next major version.


