### PR TITLE
Introduce AlgoliaIndexManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ CHANGELOG
 UNRELEASED
 ----------
 
+* Introduce AlgoliaIndexManager
+
+    By default, the bundle will use the IndexManager, in which, you can inject
+    any engine class. The point is to use this bundle with other search engine,
+    not only Algolia.
+    
+    In some cases, we want to provide extra features for Algolia users, this is why
+    this AlgoliaIndexManager class was introduced. The first feature is the ability 
+    to override the credentials. This is useful if you are using multiple algolia app
+    or if you want to use another API key for some users/use cases.
+    
+    To use the AlgoliaIndexManager, update your configuration as shown below, then
+    `$container->get('search.index_manager)` will return an AlgoliaIndexManager instance.
+    
+    ```yml
+    algolia_search:
+        index_manager: 'Algolia\SearchBundle\AlgoliaIndexManager'
+    ```
 
 3.3.2
 ----------

--- a/src/AlgoliaIndexManager.php
+++ b/src/AlgoliaIndexManager.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Algolia\SearchBundle;
+
+use Algolia\SearchBundle\Engine\AlgoliaEngine;
+
+class AlgoliaIndexManager extends IndexManager
+{
+    public function __construct($normalizer, AlgoliaEngine $engine, array $configuration)
+    {
+        parent::__construct($normalizer, $engine, $configuration);
+    }
+
+    public function setCredentials($appId, $apiKey)
+    {
+        $this->engine->setCredentials($appId, $apiKey);
+
+        return $this;
+    }
+}

--- a/src/DependencyInjection/AlgoliaSearchExtension.php
+++ b/src/DependencyInjection/AlgoliaSearchExtension.php
@@ -2,6 +2,7 @@
 
 namespace Algolia\SearchBundle\DependencyInjection;
 
+use Algolia\SearchBundle\AlgoliaIndexManager;
 use Algolia\SearchBundle\IndexManager;
 use Algolia\SearchBundle\Settings\AlgoliaSettingsManager;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -53,7 +54,7 @@ class AlgoliaSearchExtension extends Extension
         }
 
         $indexManagerDefinition = (new Definition(
-            IndexManager::class,
+            $config['index_manager'],
             [
                 new Reference($config['serializer']),
                 new Reference('search.engine'),

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -2,6 +2,7 @@
 
 namespace Algolia\SearchBundle\DependencyInjection;
 
+use Algolia\SearchBundle\IndexManager;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
@@ -40,6 +41,9 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->scalarNode('serializer')
                     ->defaultValue('serializer')
+                ->end()
+                ->scalarNode('index_manager')
+                    ->defaultValue(IndexManager::class)
                 ->end()
                 ->arrayNode('indices')
                     ->useAttributeAsKey('name')

--- a/src/Engine/AlgoliaEngine.php
+++ b/src/Engine/AlgoliaEngine.php
@@ -15,6 +15,23 @@ class AlgoliaEngine implements EngineInterface
         $this->algolia = $algolia;
     }
 
+    /**
+     * Set appId and ApiKey for underlying Algolia Client.
+     * This allow developers to use multiple app within the
+     * same Symfony application.
+     *
+     * @param string $appId
+     * @param string $apiKey
+     * @return $this
+     */
+    public function setCredentials($appId, $apiKey)
+    {
+        $this->algolia->getContext()->applicationID = $appId;
+        $this->algolia->getContext()->apiKey = $apiKey;
+
+        return $this;
+    }
+
     public function add($searchableEntities)
     {
         return $this->update($searchableEntities);

--- a/tests/Kernel.php
+++ b/tests/Kernel.php
@@ -9,7 +9,6 @@ use Symfony\Component\HttpKernel\Kernel as HttpKernel;
 
 class Kernel extends HttpKernel
 {
-
     /**
      * Returns an array of bundles to register.
      *

--- a/tests/TestCase/AlgoliaIndexManagerTest.php
+++ b/tests/TestCase/AlgoliaIndexManagerTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Algolia\SearchBundle\TestCase;
+
+use Algolia\SearchBundle\BaseTest;
+use Algolia\SearchBundle\Entity\Post;
+use AlgoliaSearch\AlgoliaException;
+
+class AlgoliaIndexManagerTest extends BaseTest
+{
+    /** @var \Algolia\SearchBundle\IndexManagerInterface */
+    protected $indexManager;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->indexManager = $this->get('search.index_manager');
+    }
+
+    public function testSetCredentials()
+    {
+        try {
+            $this->indexManager->setCredentials('xxx', 'yyy')->count('', Post::class);
+            $this->assertTrue(false, "Credentials couldn't be set in the AlgoliaIndexManager");
+        } catch (AlgoliaException $e) {
+            $this->assertContains('Invalid Application-ID or API key', $e->getMessage());
+        }
+
+        $this->indexManager->setCredentials(
+            getenv('ALGOLIA_APP_ID'),
+            getenv('ALGOLIA_API_KEY')
+        );
+    }
+}

--- a/tests/TestCase/ConfigurationTest.php
+++ b/tests/TestCase/ConfigurationTest.php
@@ -37,6 +37,7 @@ class ConfigurationTest extends BaseTest
                     "settingsDirectory" => null,
                     "doctrineSubscribedEvents" => ["postPersist", "postUpdate", "preRemove"],
                     "indices" => [],
+                    "index_manager" => "Algolia\\SearchBundle\\IndexManager",
                 ]
             ],
             'Simple config' => [
@@ -52,6 +53,7 @@ class ConfigurationTest extends BaseTest
                     "settingsDirectory" => null,
                     "doctrineSubscribedEvents" => ["postPersist", "postUpdate", "preRemove"],
                     "indices" => [],
+                    "index_manager" => "Algolia\\SearchBundle\\IndexManager",
                 ]
             ],
             'Index config' => [
@@ -80,6 +82,7 @@ class ConfigurationTest extends BaseTest
                             'index_if' => null,
                         ],
                     ],
+                    "index_manager" => "Algolia\\SearchBundle\\IndexManager",
                 ]
             ],
         ];

--- a/tests/TestCase/IndexManagerTest.php
+++ b/tests/TestCase/IndexManagerTest.php
@@ -2,10 +2,9 @@
 
 namespace Algolia\SearchBundle;
 
-use Algolia\SearchBundle\Doctrine\NullObjectManager;
 use Algolia\SearchBundle\Entity\Comment;
 use Algolia\SearchBundle\Entity\Post;
-use Algolia\SearchBundle\Entity\Tag;
+use Symfony\Component\Yaml\Yaml;
 
 class IndexManagerTest extends BaseTest
 {
@@ -23,6 +22,15 @@ class IndexManagerTest extends BaseTest
         $this->indexManager->delete(Post::class);
         $this->indexManager->delete(Comment::class);
     }
+
+    public function testIndexManagerIsSetAccordingToConfig()
+    {
+        $config = Yaml::parse(file_get_contents(__DIR__.'/../config/algolia_search.yml'));
+        $indexManagerClass = $config['algolia_search']['index_manager'];
+
+        $this->assertInstanceOf($indexManagerClass, $this->indexManager);
+    }
+
     public function testIsSearchableMethod()
     {
         $this->assertTrue($this->indexManager->isSearchable(Post::class));

--- a/tests/config/algolia_search.yml
+++ b/tests/config/algolia_search.yml
@@ -3,6 +3,7 @@ algolia_search:
     nbResults: 12
     batchSize: 100
     settingsDirectory: '/tests/cache/settings'
+    index_manager: 'Algolia\SearchBundle\AlgoliaIndexManager'
     indices:
         - name: posts
           class: 'Algolia\SearchBundle\Entity\Post'


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Need Doc update   | yes


## Describe your change

By default, the bundle will use the IndexManager, in which, you can inject
any engine class. The point is to use this bundle with other search engine,
not only Algolia.

In some cases, we want to provide extra features for Algolia users, this is why
this AlgoliaIndexManager class was introduced. The first feature is the ability 
to override the credentials. This is useful if you are using multiple algolia app
or if you want to use another API key for some users/use cases.

To use the AlgoliaIndexManager, update your configuration as shown below, then
`$container->get('search.index_manager)` will return an AlgoliaIndexManager instance.

```yml
    algolia_search:
        index_manager: 'Algolia\SearchBundle\AlgoliaIndexManager'
```

Note: I'm aware that some configuration use camelCase and some use snake_case. This was a mistake, snake_case should be used.