### PR TITLE
Re-integrate PHPStan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,4 @@ install:
     - composer install
 
 script:
-    - eval $(./algolia-keys export) && ./vendor/bin/simple-phpunit -v
+    - eval $(./algolia-keys export) && ./vendor/bin/phpunit -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,14 @@ branches:
         - master
         - 2.x
 
-before_script:
+jobs:
+    include:
+        - stage: phpstan
+          php: 7.2
+          before_install: composer require --no-update phpstan/phpstan "^0.10.6"
+          script: vendor/bin/phpstan analyse
+
+install:
     - wget https://alg.li/algolia-keys && chmod +x algolia-keys
     - composer install
 

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
         "doctrine/orm": "^2.5",
         "jms/serializer-bundle": "^2.3",
         "ocramius/proxy-manager": "*",
+        "phpunit/phpunit": "^5.7.21 || ^6.4 || ^7.0",
         "symfony/doctrine-bridge": "^3.4.0 || ^4.0.0",
         "symfony/framework-bundle": "^3.4.0 || ^4.0.0",
         "symfony/phpunit-bridge": "^3.4.0 || ^4.0",

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
         "algolia/algoliasearch-client-php": "^1.23",
         "doctrine/common": "^2.5",
         "symfony/filesystem": "^3.4.0 || ^4.0.0",
-        "symfony/serializer": "^3.4.0 || ^4.0.0",
-        "symfony/property-access": "^3.4.0 || ^4.0.0"
+        "symfony/property-access": "^3.4.0 || ^4.0.0",
+        "symfony/serializer": "^3.4.0 || ^4.0.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,4 @@
+parameters:
+  level: 1
+  paths:
+    - %rootDir%/../../../src

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -2,4 +2,4 @@ parameters:
   level: 1
   paths:
     - %rootDir%/../../../src
-    - %rootDir%/../../../Tests
+    - %rootDir%/../../../tests

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -2,3 +2,4 @@ parameters:
   level: 1
   paths:
     - %rootDir%/../../../src
+    - %rootDir%/../../../Tests

--- a/tests/TestCase/AlgoliaEngineTest.php
+++ b/tests/TestCase/AlgoliaEngineTest.php
@@ -1,6 +1,8 @@
 <?php
 
-namespace Algolia\SearchBundle;
+namespace Algolia\SearchBundle\TestCase;
+
+use Algolia\SearchBundle\BaseTest;
 
 class AlgoliaEngineTest extends BaseTest
 {

--- a/tests/TestCase/ConfigurationTest.php
+++ b/tests/TestCase/ConfigurationTest.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace Algolia\SearchBundle;
+namespace Algolia\SearchBundle\TestCase;
 
+use Algolia\SearchBundle\BaseTest;
 use Algolia\SearchBundle\DependencyInjection\Configuration;
 
 class ConfigurationTest extends BaseTest

--- a/tests/TestCase/DoctrineTest.php
+++ b/tests/TestCase/DoctrineTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Algolia\SearchBundle\AlgoliaSearch;
+namespace Algolia\SearchBundle\TestCase;
 
 use Algolia\SearchBundle\BaseTest;
 use Algolia\SearchBundle\TestApp\Entity\Comment;

--- a/tests/TestCase/IndexManagerTest.php
+++ b/tests/TestCase/IndexManagerTest.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace Algolia\SearchBundle;
+namespace Algolia\SearchBundle\TestCase;
 
+use Algolia\SearchBundle\BaseTest;
 use Algolia\SearchBundle\Doctrine\NullObjectManager;
 use Algolia\SearchBundle\TestApp\Entity\Comment;
 use Algolia\SearchBundle\TestApp\Entity\ContentAggregator;

--- a/tests/TestCase/SerializationTest.php
+++ b/tests/TestCase/SerializationTest.php
@@ -1,7 +1,10 @@
 <?php
 
-namespace Algolia\SearchBundle;
+namespace Algolia\SearchBundle\TestCase;
 
+use Algolia\SearchBundle\BaseTest;
+use Algolia\SearchBundle\Searchable;
+use Algolia\SearchBundle\SearchableEntity;
 use Algolia\SearchBundle\TestApp\Entity\Comment;
 use Algolia\SearchBundle\TestApp\Entity\Post;
 use Algolia\SearchBundle\TestApp\Entity\Tag;

--- a/tests/TestCase/SettingsTest.php
+++ b/tests/TestCase/SettingsTest.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace Algolia\SearchBundle;
+namespace Algolia\SearchBundle\TestCase;
 
+use Algolia\SearchBundle\BaseTest;
 use Algolia\SearchBundle\TestApp\Entity\Post;
 use Algolia\SearchBundle\Settings\SettingsManagerInterface;
 use AlgoliaSearch\Client;


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | 
| Need Doc update   | maybe

In #256, PHPStan was added but not included in the build pipeline. This PR re-adds it to the build as a separate stage, running it only on PHP 7.2. When testing locally, it has to be included manually.

This also fixes a few errors PHPStan found in the tests and adds `phpunit/phpunit` as a dev dependency so the tests can be properly inspected.