### PR TITLE
[2.x] Fix deprecation in data collector

### DIFF
--- a/DataCollector/ClientDataCollector.php
+++ b/DataCollector/ClientDataCollector.php
@@ -21,6 +21,7 @@ class ClientDataCollector extends DataCollector
     public function __construct(Client $client)
     {
         $this->client = $client;
+        $this->reset();
     }
 
     /**
@@ -28,11 +29,6 @@ class ClientDataCollector extends DataCollector
      */
     public function collect(Request $request, Response $response, \Exception $exception = null)
     {
-        $this->data = [
-            'transactions' => [],
-            'transactionCount' => [],
-        ];
-
         if (! $this->client instanceof DebugClientInterface) {
             return;
         }
@@ -81,5 +77,13 @@ class ClientDataCollector extends DataCollector
     public function getName()
     {
         return 'algolia.client_data_collector';
+    }
+
+    public function reset()
+    {
+        $this->data = [
+            'transactions' => [],
+            'transactionCount' => [],
+        ];
     }
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no     
| Related Issue     | 
| Need Doc update   | no


## Describe your change

This PR fixes a deprecation warning that arises when using Symfony 3.4. Implementing a data collector without a `reset` method is deprecated as the method is part of the interface in 3.4.

Note: theoretically, this change would require you tagging a new minor release because it adds a new method to the public API. In this case, I would advocate regarding this as a bugfix as the method is not relied upon by Symfony 3.4 and not part of the original data collector contract.

Note: build failures seem to stem from a missing stopwatch component.