### PR TITLE
#286: Carry over normalization context on aggregation

### DIFF
--- a/src/Entity/Aggregator.php
+++ b/src/Entity/Aggregator.php
@@ -88,6 +88,6 @@ abstract class Aggregator implements NormalizableInterface
      */
     public function normalize(NormalizerInterface $normalizer, $format = null, array $context = [])
     {
-        return array_merge(['objectID' => $this->objectID], $normalizer->normalize($this->entity));
+        return array_merge(['objectID' => $this->objectID], $normalizer->normalize($this->entity, $format, $context));
     }
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | Fix #286 
| Need Doc update   | no


## Describe your change
Aggregator was not properly caring over normalization context - now it does.

## What problem is this fixing?
- Custom normalizers are loosing information about grouping (esp. important for #283)
- Groups are half-used because they are effectively disabled by loosing the context

## WIP?
Can someone suggest how to properly test this? Aggregator is not unit tested but only functional tested, but I don't want to add functional tests for aggregator + groups since it will be a massive diff to fix other places ;)
