### PR TITLE
Add missing php dependency to composer.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,11 @@ php:
     - 7.1
     - 7.2
     - 7.3
-    - nightly
+    - 7.4snapshot
 
 matrix:
     allow_failures:
-        - php: nightly
+        - php: 7.4snapshot
 
 branches:
     only:

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     ],
     "prefer-stable": true,
     "require": {
+        "php": "^5.6 || ^7.0",
         "algolia/algoliasearch-client-php": "^1.23",
         "doctrine/common": "^2.5",
         "symfony/filesystem": "^3.4.0 || ^4.0.0",


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | yeah...no
| Related Issue     | -
| Need Doc update   | no


## Describe your change

`composer.json` has no PHP requirement. This allows installing this package on systems that aren't compatible (e.g. PHP 5.2). This PR adds a requirement of PHP 5.6 or any 7.* package. This was deduced from the currently tested PHP versions in travis-ci. If support for older PHP versions should be kept, I suggest adding these to the build pipeline as well.

This PR also updates travis-ci to test against snapshots for PHP 7.4 as `nightly` now refers to PHP 8.0 which this library can't support.