### PR TITLE
Add searchCollection()

### DIFF
--- a/src/IndexManager.php
+++ b/src/IndexManager.php
@@ -4,8 +4,10 @@ namespace Algolia\SearchBundle;
 
 use Algolia\SearchBundle\Entity\Aggregator;
 use Algolia\SearchBundle\Engine\EngineInterface;
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\Common\Util\ClassUtils;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Config\Definition\Exception\Exception;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 
@@ -144,6 +146,22 @@ class IndexManager implements IndexManagerInterface
         }
 
         return $results;
+    }
+
+    public function searchCollection($query, $className, EntityManagerInterface $objectManager, array $parameters = [])
+    {
+        $this->assertIsSearchable($className);
+        $ids = $this->engine->searchIds($query, $this->getFullIndexName($className), 1, 1000, $parameters);
+
+        $results = new ArrayCollection();
+
+        foreach ($ids as $objectID) {
+        	 $entityRef = $objectManager->getReference($className, $objectID);
+
+        	 $results->add($entityRef);
+        }
+
+    	return $results;
     }
 
     public function rawSearch($query, $className, $page = 1, $nbResults = null, array $parameters = [])

--- a/src/IndexManager.php
+++ b/src/IndexManager.php
@@ -133,7 +133,10 @@ class IndexManager implements IndexManagerInterface
             }
 
             $repo = $objectManager->getRepository($entityClass);
-            $entity = $repo->findOneBy(['id' => $id]);
+            $meta = $objectManager->getClassMetadata($entityClass);
+            $idField = $meta->getIdentifier()[0];
+
+            $entity = $repo->findOneBy([$idField => $id]);
 
             if ($entity !== null) {
                 $results[] = $entity;


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          |no
| New feature?      | yes
| BC breaks?        | no     
| Related Issue     | Fix #307
| Need Doc update   | yes


## Describe your change
Added new method `searchCollection()` to allow pulling all entity references into an ArrayCollection for pagination.

## What problem is this fixing?
As per the referenced issue, there was no way to paginate search results without using `rawSearch()`. This code change pulls in all IDs (up to 1000) and adds them to an ArrayCollection so they can be lazy loaded by Doctrine later.
