### PR TITLE
Addition of object overview in exception message

### DIFF
--- a/src/Entity/Aggregator.php
+++ b/src/Entity/Aggregator.php
@@ -43,6 +43,11 @@ abstract class Aggregator implements NormalizableInterface
         $this->objectID = get_class($this->entity).'::'.reset($entityIdentifierValues);
     }
 
+    public function getObjectID()
+    {
+        return $this->objectID;
+    }
+
     /**
      * Returns the entities class names that should be aggregated.
      *


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | Fix #160
| Need Doc update   | yes


## Describe your change

When trying to index an oversized element, the thrown exception has been tweaked: it now displays more information about the element that exceeds accepted length.
Moreover, the method `getObjectID` was added in the Aggregator class.

## What problem is this fixing?

It gives more information about what element to update to make your import command work smoothly