### PR TITLE
fix(interal-searchable): remove internal tag from Searchable class

### DIFF
--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -218,7 +218,6 @@ used directly and may be up to changes in minor versions.
 * `Algolia\SearchBundle\DependencyInjection\AlgoliaSearchExtension`
 * `Algolia\SearchBundle\DependencyInjection\Configuration`
 * `Algolia\SearchBundle\EventListener\SearchIndexerSubscriber`
-* `Algolia\SearchBundle\Searchable`
 * `Algolia\SearchBundle\SearchableEntity`
 * `Algolia\SearchBundle\SettingsManager`
 

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -2,9 +2,6 @@
 
 namespace Algolia\SearchBundle;
 
-/**
- * @internal
- */
 final class Searchable
 {
     const NORMALIZATION_FORMAT = 'searchableArray';


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | Fix #313 
| Need Doc update   | no


## Describe your change

`Searchable` class needs to be used during normalization, so it can't be `@internal`