### PR TITLE
Add support for MongoDB ODM 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         }
     },
     "conflict": {
-        "doctrine/mongodb-odm": ">= 2.0"
+        "doctrine/mongodb-odm": "< 1.3"
     },
     "autoload-dev": {
         "psr-4": {

--- a/src/Resources/config/doctrine/Aggregator.mongodb.xml
+++ b/src/Resources/config/doctrine/Aggregator.mongodb.xml
@@ -5,6 +5,6 @@
                         http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
 
     <mapped-superclass name="Algolia\SearchBundle\Document\Aggregator">
-        <field name="objectID" id="true" />
+        <id field-name="objectID" />
     </mapped-superclass>
 </doctrine-mongo-mapping>


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | -
| Need Doc update   | no


## Describe your change

This changes the mapping for the aggregator class for MongoDB ODM to allow running this bundle with ODM 1.3 or 2.0 (and newer).

## What problem is this fixing?

As indicated in https://github.com/algolia/search-bundle/pull/257#discussion_r240299734, ODM 2.0 brings new mappings. At the time, there was no forward compatibility layer and 2.0 wasn't released. In ODM 1.3, we introduce the same kind of identifier mapping that ODM 2.0 has. This allows bundles to support mappings for 1.3 and 2.x at the same time.

This comes at the cost for removing support for ODM < 1.3. Considering that this targets a new major release of the search bundle, that Doctrine no longer supports ODM 1.2 and older, and that users of 1.2 can upgrade to 1.3 without having to change their code I find this an acceptable change to future-proof this library.