### PR TITLE
fix: allows extend null search service

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -13,3 +13,4 @@ parameters:
         - '#(Method|Function|Constructor).*has parameter.*with.*default value.#'
         - '#Call to an undefined method Symfony\\Component\\Config\\Definition\\Builder\\NodeDefinition::children\(\).#'
         - '#Call to an undefined method Doctrine\\Common\\Persistence\\ObjectRepository::clear\(\).#'
+        - '#Class Algolia\\SearchBundle\\Services\\NullSearchService is neither abstract nor final.#'

--- a/src/Services/NullSearchService.php
+++ b/src/Services/NullSearchService.php
@@ -8,10 +8,10 @@ use Algolia\SearchBundle\SearchService;
 use Doctrine\Common\Persistence\ObjectManager;
 
 /**
- * This class aims to be used in dev or testing environments.
- * It may be subject to breaking changes.
+ * This class aims to be used in dev or testing environments. It may
+ * be subject to breaking changes.
  */
-final class NullSearchService implements SearchService
+class NullSearchService implements SearchService
 {
     /**
      * @param string $className


### PR DESCRIPTION
This class is not covered by semantic versioning anyway, so let's make it non final as proposed here https://github.com/algolia/search-bundle/issues/322.