### PR TITLE
Add atomic reindex support, via --atomic flag in search:import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased](https://github.com/algolia/search-bundle/compare/4.0.0...master)
 
+- Feature: Adds atomic reindex support, via --atomic flag in search:import
+
 ## [v4.0.0](https://github.com/algolia/search-bundle/compare/3.4.0...4.0.0)
 
 ### Changed

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -8,6 +8,10 @@
 
         <prototype namespace="Algolia\SearchBundle\Command\" resource="../../Command" autowire="true" autoconfigure="true" />
 
+        <service id="Algolia\SearchBundle\Command\SearchImportCommand" autowire="true" autoconfigure="true">
+            <argument key="$searchServiceForAtomicReindex" type="service" id="search.service_for_atomic_reindex" />
+        </service>
+
         <service id="search.search_indexer_subscriber" class="Algolia\SearchBundle\EventListener\SearchIndexerSubscriber" public="true">
             <argument type="service" id="search.service" />
             <argument type="collection" /> <!-- doctrine subscribed events -->

--- a/tests/TestCase/CommandsTest.php
+++ b/tests/TestCase/CommandsTest.php
@@ -132,7 +132,10 @@ class CommandsTest extends BaseTest
         $this->cleanUp();
     }
 
-    public function testSearchImport()
+    /**
+     * @testWith [true, false]
+     */
+    public function testSearchImport($isAtomic)
     {
         $now = new \DateTime();
         $this->connection->insert($this->indexName, [
@@ -154,8 +157,9 @@ class CommandsTest extends BaseTest
         $command       = $this->application->find('search:import');
         $commandTester = new CommandTester($command);
         $commandTester->execute([
-            'command'   => $command->getName(),
-            '--indices' => $this->indexName,
+            'command'    => $command->getName(),
+            '--indices'  => $this->indexName,
+            '--atomic'   => $isAtomic,
         ]);
 
         // Checks output


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no     
| Related Issue     | Fix #292
| Need Doc update   | yes

0 downtime `search:clear && search:import` solution

<img width="851" alt="Screenshot 2019-11-16 at 19 22 17" src="https://user-images.githubusercontent.com/496233/68997414-747a8000-08a6-11ea-9ad3-64061a405b6a.png">

