### PR TITLE
Strip extra slashes from settingsDirectory

### DIFF
--- a/src/DependencyInjection/AlgoliaSearchExtension.php
+++ b/src/DependencyInjection/AlgoliaSearchExtension.php
@@ -43,9 +43,9 @@ final class AlgoliaSearchExtension extends Extension
 
         if (is_null($config['settingsDirectory'])) {
             if (Kernel::MAJOR_VERSION >= 3 && !is_dir($rootDir . '/config/')) {
-                $config['settingsDirectory'] = '/app/Resources/SearchBundle/settings/';
+                $config['settingsDirectory'] = '/app/Resources/SearchBundle/settings';
             } else {
-                $config['settingsDirectory'] = '/config/settings/algolia_search/';
+                $config['settingsDirectory'] = '/config/settings/algolia_search';
             }
         }
 


### PR DESCRIPTION
Slashes are added by SettingsManager

| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | 
| Need Doc update   | 

Fixes following

![Screenshot 2019-11-26 at 17 00 38](https://user-images.githubusercontent.com/496233/69650130-6da1f900-106e-11ea-8a18-2b5dd1a3270c.png)
