### PR TITLE
Use ClassUtils from Doctrine into Aggregator constructor to avoid having Proxy into Algolia

### DIFF
--- a/src/Model/Aggregator.php
+++ b/src/Model/Aggregator.php
@@ -6,6 +6,7 @@ use Algolia\SearchBundle\Exception\EntityNotFoundInObjectID;
 use Algolia\SearchBundle\Exception\InvalidEntityForAggregator;
 use Symfony\Component\Serializer\Normalizer\NormalizableInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Doctrine\Common\Util\ClassUtils;
 
 abstract class Aggregator implements NormalizableInterface
 {
@@ -38,7 +39,7 @@ abstract class Aggregator implements NormalizableInterface
             throw new InvalidEntityForAggregator("Aggregators don't support more than one primary key.");
         }
 
-        $this->objectID = get_class($this->entity) . '::' . reset($entityIdentifierValues);
+        $this->objectID = ClassUtils::getClass($this->entity) . '::' . reset($entityIdentifierValues);
     }
 
     /**

--- a/tests/TestCase/AggregatorTest.php
+++ b/tests/TestCase/AggregatorTest.php
@@ -8,9 +8,27 @@ use Algolia\SearchBundle\Exception\InvalidEntityForAggregator;
 use Algolia\SearchBundle\TestApp\Entity\ContentAggregator;
 use Algolia\SearchBundle\TestApp\Entity\EmptyAggregator;
 use Algolia\SearchBundle\TestApp\Entity\Post;
+use Doctrine\Common\Proxy\ProxyGenerator;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
 
 class AggregatorTest extends BaseTest
 {
+    /**
+     * @var EntityManagerInterface
+     */
+    protected $entityManager;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $application = new Application(self::$kernel);
+        $this->refreshDb($application);
+
+        $this->entityManager  = $this->get('doctrine')->getManager();
+    }
+
     public function testGetEntities()
     {
         $entites = EmptyAggregator::getEntities();
@@ -29,5 +47,28 @@ class AggregatorTest extends BaseTest
         $this->expectException(InvalidEntityForAggregator::class);
         $post                = new Post();
         $compositeAggregator = new ContentAggregator($post, ['objectId', 'url']);
+    }
+
+    public function testAggregatorProxyClass()
+    {
+        $post = new Post([
+            'id' => 1,
+            'title' => 'Test',
+            'content' => 'Test content',
+        ]);
+        $this->entityManager->persist($post);
+        $this->entityManager->flush();
+
+        $postMetadata = $this->entityManager->getClassMetadata(Post::class);
+        $this->entityManager->getProxyFactory()->generateProxyClasses([$postMetadata], null);
+
+        $proxy = $this->entityManager->getProxyFactory()->getProxy($postMetadata->getName(), ['id' => 1]);
+        $contentAggregator = new ContentAggregator($proxy, ['objectId']);
+
+        $serializer = $this->get('serializer');
+
+        $serializedData = $contentAggregator->normalize($serializer);
+        $this->assertNotEmpty($serializedData);
+        $this->assertEquals('Algolia\SearchBundle\TestApp\Entity\Post::objectId', $serializedData['objectID']);
     }
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | Fix #339
| Need Doc update   | no


## Describe your change

Instead of using `get_class` use the `ClassUtils` from doctrine project to replace Proxy class to real class.

## What problem is this fixing?

https://github.com/algolia/search-bundle/issues/339
