### PR TITLE
Add `bool` type to `$requestOptions` array

### DIFF
--- a/src/SearchService.php
+++ b/src/SearchService.php
@@ -34,41 +34,41 @@ interface SearchService
     public function searchableAs($className);
 
     /**
-     * @param object|array<int, object>                      $searchables
-     * @param array<string, int|string|array>|RequestOptions $requestOptions
+     * @param object|array<int, object>                           $searchables
+     * @param array<string, int|string|bool|array>|RequestOptions $requestOptions
      *
      * @return \Algolia\AlgoliaSearch\Response\AbstractResponse
      */
     public function index(ObjectManager $objectManager, $searchables, $requestOptions = []);
 
     /**
-     * @param object|array<int, object>                      $searchables
-     * @param array<string, int|string|array>|RequestOptions $requestOptions
+     * @param object|array<int, object>                           $searchables
+     * @param array<string, int|string|bool|array>|RequestOptions $requestOptions
      *
      * @return \Algolia\AlgoliaSearch\Response\AbstractResponse
      */
     public function remove(ObjectManager $objectManager, $searchables, $requestOptions = []);
 
     /**
-     * @param string                                         $className
-     * @param array<string, int|string|array>|RequestOptions $requestOptions
+     * @param string                                              $className
+     * @param array<string, int|string|bool|array>|RequestOptions $requestOptions
      *
      * @return \Algolia\AlgoliaSearch\Response\AbstractResponse
      */
     public function clear($className, $requestOptions = []);
 
     /**
-     * @param string                                         $className
-     * @param array<string, int|string|array>|RequestOptions $requestOptions
+     * @param string                                              $className
+     * @param array<string, int|string|bool|array>|RequestOptions $requestOptions
      *
      * @return \Algolia\AlgoliaSearch\Response\AbstractResponse
      */
     public function delete($className, $requestOptions = []);
 
     /**
-     * @param string                                         $className
-     * @param string                                         $query
-     * @param array<string, int|string|array>|RequestOptions $requestOptions
+     * @param string                                              $className
+     * @param string                                              $query
+     * @param array<string, int|string|bool|array>|RequestOptions $requestOptions
      *
      * @return array<int, object>
      *
@@ -77,9 +77,9 @@ interface SearchService
     public function search(ObjectManager $objectManager, $className, $query = '', $requestOptions = []);
 
     /**
-     * @param string                                         $className
-     * @param string                                         $query
-     * @param array<string, int|string|array>|RequestOptions $requestOptions
+     * @param string                                              $className
+     * @param string                                              $query
+     * @param array<string, int|string|bool|array>|RequestOptions $requestOptions
      *
      * @return array<string, int|string|bool|array>
      *
@@ -88,9 +88,9 @@ interface SearchService
     public function rawSearch($className, $query = '', $requestOptions = []);
 
     /**
-     * @param string                                         $className
-     * @param string                                         $query
-     * @param array<string, int|string|array>|RequestOptions $requestOptions
+     * @param string                                              $className
+     * @param string                                              $query
+     * @param array<string, int|string|array|bool>|RequestOptions $requestOptions
      *
      * @return int
      *


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      |no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     |  <!-- will close issue automatically, if any -->
| Need Doc update   |no


## Describe your change

Added `bool` type to $requestOptions array.

## What problem is this fixing?

The API-parameter `typoTolerance` allows boolean values. Those `bool` values should also be supported by `$requestOptions`.
Example:
```php
$searchService->search(
    $objectManager,
    $className,
    $query,
    [
        "typoTolerance" => true,
    ]
);
```
