### PR TITLE
Update Doctrine components and add Symfony 5.2 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,4 +84,4 @@ workflows:
       - test:
           matrix:
             parameters:
-              version: ['7.1', '7.2', '7.3', '7.4']
+              version: ['7.2', '7.3', '7.4', '8.0']

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,4 +86,4 @@ workflows:
       - test:
           matrix:
             parameters:
-              version: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4']
+              version: ['7.1', '7.2', '7.3', '7.4']

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,9 +76,7 @@ jobs:
 
       - run:
           name: Check coverage
-          command: |
-            if (( $(echo "<<parameters.version>> >= 7.2" |bc -l) )); then php coverage-checker.php clover.xml 100; fi
-            if (( $(echo "<<parameters.version>> < 7.2" |bc -l) )); then php coverage-checker.php clover.xml 100; fi
+          command: php coverage-checker.php clover.xml 100
 
 workflows:
   workflow:

--- a/composer.json
+++ b/composer.json
@@ -32,11 +32,12 @@
         }
     },
     "require-dev": {
+        "ext-json": "*",
         "doctrine/doctrine-bundle": "^1.8 || ^2.0",
         "doctrine/orm": "^2.5",
         "jms/serializer-bundle": "^3.0",
         "ocramius/proxy-manager": "*",
-        "phpunit/phpunit": "^5.7.21 || ^6.4 || ^7.0",
+        "phpunit/phpunit": "^8.5 || ^9.0",
         "symfony/framework-bundle": "^3.4 || ^4.0 || ^5.0",
         "symfony/phpunit-bridge": "^3.4 || ^4.0 || ^5.0",
         "symfony/proxy-manager-bridge": "*",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,9 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "algolia/algoliasearch-client-php": "^2.5",
-        "doctrine/common": "^2.5",
+        "doctrine/event-manager": "^1.1",
+        "symfony/doctrine-bridge": "^3.4 || ^4.0 || ^5.0",
+        "doctrine/persistence": "^2.1",
         "symfony/filesystem": "^3.4 || ^4.0 || ^5.0",
         "symfony/property-access": "^3.4 || ^4.0 || ^5.0",
         "symfony/serializer": "^3.4 || ^4.0 || ^5.0"
@@ -36,7 +38,6 @@
         "jms/serializer-bundle": "^2.3 || ^3.0",
         "ocramius/proxy-manager": "*",
         "phpunit/phpunit": "^5.7.21 || ^6.4 || ^7.0",
-        "symfony/doctrine-bridge": "^3.4 || ^4.0 || ^5.0",
         "symfony/framework-bundle": "^3.4 || ^4.0 || ^5.0",
         "symfony/phpunit-bridge": "^3.4 || ^4.0 || ^5.0",
         "symfony/proxy-manager-bridge": "*",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,6 @@
         "php": "^5.6 || ^7.0",
         "algolia/algoliasearch-client-php": "^2.5",
         "doctrine/event-manager": "^1.1",
-        "symfony/doctrine-bridge": "^3.4 || ^4.0 || ^5.0",
         "doctrine/persistence": "^2.1",
         "symfony/filesystem": "^3.4 || ^4.0 || ^5.0",
         "symfony/property-access": "^3.4 || ^4.0 || ^5.0",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "prefer-stable": true,
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.1",
         "algolia/algoliasearch-client-php": "^2.5",
         "doctrine/event-manager": "^1.1",
         "doctrine/persistence": "^2.1",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "prefer-stable": true,
     "require": {
-        "php": "^7.1",
+        "php": "^7.2 || ^8.0",
         "algolia/algoliasearch-client-php": "^2.5",
         "doctrine/event-manager": "^1.1",
         "doctrine/persistence": "^2.1",
@@ -34,7 +34,7 @@
     "require-dev": {
         "doctrine/doctrine-bundle": "^1.8 || ^2.0",
         "doctrine/orm": "^2.5",
-        "jms/serializer-bundle": "^2.3 || ^3.0",
+        "jms/serializer-bundle": "^3.0",
         "ocramius/proxy-manager": "*",
         "phpunit/phpunit": "^5.7.21 || ^6.4 || ^7.0",
         "symfony/framework-bundle": "^3.4 || ^4.0 || ^5.0",

--- a/src/Command/SearchImportCommand.php
+++ b/src/Command/SearchImportCommand.php
@@ -5,7 +5,7 @@ namespace Algolia\SearchBundle\Command;
 use Algolia\AlgoliaSearch\SearchClient;
 use Algolia\SearchBundle\Entity\Aggregator;
 use Algolia\SearchBundle\SearchService;
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;

--- a/src/EventListener/SearchIndexerSubscriber.php
+++ b/src/EventListener/SearchIndexerSubscriber.php
@@ -4,7 +4,7 @@ namespace Algolia\SearchBundle\EventListener;
 
 use Algolia\SearchBundle\SearchService;
 use Doctrine\Common\EventSubscriber;
-use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
+use Doctrine\Persistence\Event\LifecycleEventArgs;
 
 /**
  * @internal

--- a/src/Model/Aggregator.php
+++ b/src/Model/Aggregator.php
@@ -4,7 +4,7 @@ namespace Algolia\SearchBundle\Model;
 
 use Algolia\SearchBundle\Exception\EntityNotFoundInObjectID;
 use Algolia\SearchBundle\Exception\InvalidEntityForAggregator;
-use Doctrine\Common\Util\ClassUtils;
+use Algolia\SearchBundle\Util\ClassInfo;
 use Symfony\Component\Serializer\Normalizer\NormalizableInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
@@ -39,7 +39,7 @@ abstract class Aggregator implements NormalizableInterface
             throw new InvalidEntityForAggregator("Aggregators don't support more than one primary key.");
         }
 
-        $this->objectID = ClassUtils::getClass($this->entity) . '::' . reset($entityIdentifierValues);
+        $this->objectID = ClassInfo::getClass($this->entity) . '::' . reset($entityIdentifierValues);
     }
 
     /**

--- a/src/SearchService.php
+++ b/src/SearchService.php
@@ -3,7 +3,7 @@
 namespace Algolia\SearchBundle;
 
 use Algolia\AlgoliaSearch\RequestOptions\RequestOptions;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 
 interface SearchService
 {

--- a/src/Services/AlgoliaSearchService.php
+++ b/src/Services/AlgoliaSearchService.php
@@ -8,8 +8,8 @@ use Algolia\SearchBundle\Entity\Aggregator;
 use Algolia\SearchBundle\Responses\SearchServiceResponse;
 use Algolia\SearchBundle\SearchableEntity;
 use Algolia\SearchBundle\SearchService;
-use Doctrine\Common\Persistence\ObjectManager;
-use Doctrine\Common\Util\ClassUtils;
+use Algolia\SearchBundle\Util\ClassInfo;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\Config\Definition\Exception\Exception;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 
@@ -91,7 +91,7 @@ final class AlgoliaSearchService implements SearchService
     public function isSearchable($className)
     {
         if (is_object($className)) {
-            $className = ClassUtils::getClass($className);
+            $className = ClassInfo::getClass($className);
         }
 
         return in_array($className, $this->searchableEntities, true);
@@ -277,7 +277,7 @@ final class AlgoliaSearchService implements SearchService
      */
     public function shouldBeIndexed($entity)
     {
-        $className    = ClassUtils::getClass($entity);
+        $className    = ClassInfo::getClass($entity);
         $propertyPath = $this->indexIfMapping[$className];
 
         if ($propertyPath !== null) {
@@ -404,7 +404,7 @@ final class AlgoliaSearchService implements SearchService
         foreach (array_chunk($entities, $this->configuration['batchSize']) as $chunk) {
             $searchableEntitiesChunk = [];
             foreach ($chunk as $entity) {
-                $entityClassName = ClassUtils::getClass($entity);
+                $entityClassName = ClassInfo::getClass($entity);
 
                 $searchableEntitiesChunk[] = new SearchableEntity(
                     $this->searchableAs($entityClassName),
@@ -433,7 +433,7 @@ final class AlgoliaSearchService implements SearchService
         $aggregators = [];
 
         foreach ($entities as $entity) {
-            $entityClassName = ClassUtils::getClass($entity);
+            $entityClassName = ClassInfo::getClass($entity);
             if (array_key_exists($entityClassName, $this->entitiesAggregators)) {
                 foreach ($this->entitiesAggregators[$entityClassName] as $aggregator) {
                     $aggregators[] = new $aggregator($entity, $objectManager->getClassMetadata($entityClassName)->getIdentifierValues($entity));

--- a/src/Services/NullSearchService.php
+++ b/src/Services/NullSearchService.php
@@ -5,7 +5,7 @@ namespace Algolia\SearchBundle\Services;
 use Algolia\AlgoliaSearch\RequestOptions\RequestOptions;
 use Algolia\AlgoliaSearch\Response\NullResponse;
 use Algolia\SearchBundle\SearchService;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 
 /**
  * This class aims to be used in dev or testing environments. It may

--- a/src/Util/ClassInfo.php
+++ b/src/Util/ClassInfo.php
@@ -52,6 +52,9 @@ final class ClassInfo
         );
     }
 
+    /**
+     * @codeCoverageIgnore
+     */
     private function __construct()
     {
     }

--- a/src/Util/ClassInfo.php
+++ b/src/Util/ClassInfo.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Algolia\SearchBundle\Util;
+
+/**
+ * Retrieves information about a class.
+ *
+ * @internal
+ */
+final class ClassInfo
+{
+    /**
+     * Get class name of the given object.
+     *
+     * @param object $object
+     *
+     * @return string
+     */
+    public static function getClass($object)
+    {
+        return self::getRealClassName(get_class($object));
+    }
+
+    /**
+     * Get the real class name of a class name that could be a proxy.
+     *
+     * @param string $className
+     *
+     * @return string
+     */
+    public static function getRealClassName($className)
+    {
+        // Define variable for static analysis
+        $positionPm = false;
+        // __CG__: Doctrine Common Marker for Proxy (ODM < 2.0 and ORM < 3.0)
+        // __PM__: Ocramius Proxy Manager (ODM >= 2.0)
+        if ((false === $positionCg = strrpos($className, '\\__CG__\\')) &&
+            (false === $positionPm = strrpos($className, '\\__PM__\\'))) {
+            return $className;
+        }
+
+        if (false !== $positionCg) {
+            return substr($className, $positionCg + 8);
+        }
+
+        $className = ltrim($className, '\\');
+
+        return substr(
+            $className,
+            8 + $positionPm,
+            strrpos($className, '\\') - ($positionPm + 8)
+        );
+    }
+
+    private function __construct()
+    {
+    }
+}

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -11,31 +11,16 @@ use Symfony\Component\Console\Output\ConsoleOutput;
 
 class BaseTest extends KernelTestCase
 {
-    public static function setUpBeforeClass()
+    public function setUp(): void
     {
-        /*
-         * Older version of PHPUnit (<6.0) load
-         * env variables differently, we override them
-         * here to make sure they're coming from the
-         * env rather than the XML config
-         */
-        if (class_exists('\PHPUnit_Runner_Version')) {
-            $_ENV['ALGOLIA_PREFIX']    = getenv('ALGOLIA_PREFIX');
-            $_ENV['CIRCLE_BUILD_NUM']  = getenv('CIRCLE_BUILD_NUM');
-        }
+        self::bootKernel();
     }
 
-    public function setUp()
-    {
-        $this->bootKernel();
-    }
-
-    protected function createPost($id = null)
+    protected function createPost($id = null): Post
     {
         $post = new Post();
         $post->setTitle('Test');
         $post->setContent('Test content');
-
         if (!is_null($id)) {
             $post->setId($id);
         }
@@ -43,9 +28,9 @@ class BaseTest extends KernelTestCase
         return $post;
     }
 
-    protected function createSearchablePost()
+    protected function createSearchablePost(): SearchableEntity
     {
-        $post = $this->createPost(rand(100, 300));
+        $post = $this->createPost(random_int(100, 300));
 
         return new SearchableEntity(
             $this->getPrefix() . 'posts',
@@ -55,7 +40,7 @@ class BaseTest extends KernelTestCase
         );
     }
 
-    protected function createComment($id = null)
+    protected function createComment($id = null): Comment
     {
         $comment = new Comment();
         $comment->setContent('Comment content');
@@ -68,7 +53,7 @@ class BaseTest extends KernelTestCase
         return $comment;
     }
 
-    protected function createImage($id = null)
+    protected function createImage($id = null): Image
     {
         $image = new Image();
 
@@ -79,9 +64,9 @@ class BaseTest extends KernelTestCase
         return $image;
     }
 
-    protected function createSearchableImage()
+    protected function createSearchableImage(): SearchableEntity
     {
-        $image = $this->createImage(rand(100, 300));
+        $image = $this->createImage(random_int(100, 300));
 
         return new SearchableEntity(
             $this->getPrefix() . 'image',
@@ -91,17 +76,17 @@ class BaseTest extends KernelTestCase
         );
     }
 
-    protected function getPrefix()
+    protected function getPrefix(): ?string
     {
         return $this->get('search.service')->getConfiguration()['prefix'];
     }
 
-    protected function get($id)
+    protected function get($id): ?object
     {
         return self::$kernel->getContainer()->get($id);
     }
 
-    protected function refreshDb($application)
+    protected function refreshDb($application): void
     {
         $inputs = [
             new ArrayInput([
@@ -122,12 +107,17 @@ class BaseTest extends KernelTestCase
         }
     }
 
-    protected function getFileName($indexName, $type)
+    protected function getFileName($indexName, $type): string
     {
-        return sprintf('%s/%s-%s.json', $this->get('search.service')->getConfiguration()['settingsDirectory'], $indexName, $type);
+        return sprintf(
+            '%s/%s-%s.json',
+            $this->get('search.service')->getConfiguration()['settingsDirectory'],
+            $indexName,
+            $type
+        );
     }
 
-    protected function getDefaultConfig()
+    protected function getDefaultConfig(): array
     {
         return [
             'hitsPerPage'       => 20,

--- a/tests/Kernel.php
+++ b/tests/Kernel.php
@@ -13,7 +13,7 @@ class Kernel extends HttpKernel
      *
      * @return BundleInterface[] An array of bundle instances
      */
-    public function registerBundles()
+    public function registerBundles(): array
     {
         return [
             new \Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
@@ -28,7 +28,7 @@ class Kernel extends HttpKernel
      *
      * @param LoaderInterface $loader A LoaderInterface instance
      */
-    public function registerContainerConfiguration(LoaderInterface $loader)
+    public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         $loader->load(__DIR__ . '/config/config.yml');
 

--- a/tests/Normalizer/CommentNormalizer.php
+++ b/tests/Normalizer/CommentNormalizer.php
@@ -7,7 +7,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class CommentNormalizer implements NormalizerInterface
 {
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array
     {
         return [
             'content'    => $object->getContent(),
@@ -15,7 +15,7 @@ class CommentNormalizer implements NormalizerInterface
         ];
     }
 
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof Comment;
     }

--- a/tests/TestApp/Entity/Comment.php
+++ b/tests/TestApp/Entity/Comment.php
@@ -48,10 +48,10 @@ class Comment
 
     public function __construct(array $attributes = [])
     {
-        $this->id          = isset($attributes['id']) ? $attributes['id'] : null;
-        $this->content     = isset($attributes['content']) ? $attributes['content'] : null;
-        $this->publishedAt = isset($attributes['publishedAt']) ? $attributes['publishedAt'] : new \DateTime();
-        $this->post        = isset($attributes['post']) ? $attributes['post'] : null;
+        $this->id          = $attributes['id'] ?? null;
+        $this->content     = $attributes['content'] ?? null;
+        $this->publishedAt = $attributes['publishedAt'] ?? new \DateTime();
+        $this->post        = $attributes['post'] ?? null;
     }
 
     public function getId()

--- a/tests/TestApp/Entity/ContentAggregator.php
+++ b/tests/TestApp/Entity/ContentAggregator.php
@@ -10,7 +10,7 @@ use Doctrine\ORM\Mapping as ORM;
  */
 class ContentAggregator extends Aggregator
 {
-    public function getIsVisible()
+    public function getIsVisible(): bool
     {
         if ($this->entity instanceof Post) {
             return $this->entity->getTitle() !== 'Foo';
@@ -19,7 +19,7 @@ class ContentAggregator extends Aggregator
         return true;
     }
 
-    public static function getEntities()
+    public static function getEntities(): array
     {
         return [
             Post::class,

--- a/tests/TestApp/Entity/Image.php
+++ b/tests/TestApp/Entity/Image.php
@@ -25,8 +25,8 @@ class Image
 
     public function __construct(array $attributes = [])
     {
-        $this->id  = isset($attributes['id']) ? $attributes['id'] : null;
-        $this->url = isset($attributes['url']) ? $attributes['url'] : '/wp-content/uploads/flamingo.jpg';
+        $this->id  = $attributes['id'] ?? null;
+        $this->url = $attributes['url'] ?? '/wp-content/uploads/flamingo.jpg';
     }
 
     public function getId()

--- a/tests/TestApp/Entity/Link.php
+++ b/tests/TestApp/Entity/Link.php
@@ -27,9 +27,9 @@ class Link implements NormalizableInterface
 
     public function __construct(array $attributes = [])
     {
-        $this->id   = isset($attributes['id']) ? $attributes['id'] : null;
-        $this->name = isset($attributes['name']) ? $attributes['name'] : 'This is a tag';
-        $this->url  = isset($attributes['url']) ? $attributes['url'] : null;
+        $this->id   = $attributes['id'] ?? null;
+        $this->name = $attributes['name'] ?? 'This is a tag';
+        $this->url  = $attributes['url'] ?? null;
     }
 
     private function isSponsored()

--- a/tests/TestApp/Entity/Post.php
+++ b/tests/TestApp/Entity/Post.php
@@ -59,10 +59,10 @@ class Post
 
     public function __construct(array $attributes = [])
     {
-        $this->id          = isset($attributes['id']) ? $attributes['id'] : null;
-        $this->title       = isset($attributes['title']) ? $attributes['title'] : null;
-        $this->content     = isset($attributes['content']) ? $attributes['content'] : null;
-        $this->publishedAt = isset($attributes['publishedAt']) ? $attributes['publishedAt'] : new \DateTime();
+        $this->id          = $attributes['id'] ?? null;
+        $this->title       = $attributes['title'] ?? null;
+        $this->content     = $attributes['content'] ?? null;
+        $this->publishedAt = $attributes['publishedAt'] ?? new \DateTime();
         $this->comments    = isset($attributes['comments']) ? new ArrayCollection($attributes['comments']) : new ArrayCollection();
     }
 

--- a/tests/TestApp/Entity/Tag.php
+++ b/tests/TestApp/Entity/Tag.php
@@ -35,11 +35,11 @@ class Tag implements NormalizableInterface
 
     public function __construct(array $attributes = [])
     {
-        $this->id          = isset($attributes['id']) ? $attributes['id'] : null;
-        $this->name        = isset($attributes['name']) ? $attributes['name'] : 'This is a tag';
-        $this->count       = isset($attributes['count']) ? $attributes['count'] : 0;
-        $this->public      = isset($attributes['public']) ? $attributes['public'] : true;
-        $this->publishedAt = isset($attributes['publishedAt']) ? $attributes['publishedAt'] : new \DateTime();
+        $this->id          = $attributes['id'] ?? null;
+        $this->name        = $attributes['name'] ?? 'This is a tag';
+        $this->count       = $attributes['count'] ?? 0;
+        $this->public      = $attributes['public'] ?? true;
+        $this->publishedAt = $attributes['publishedAt'] ?? new \DateTime();
     }
 
     public function isPublic()

--- a/tests/TestCase/AggregatorTest.php
+++ b/tests/TestCase/AggregatorTest.php
@@ -10,6 +10,7 @@ use Algolia\SearchBundle\TestApp\Entity\EmptyAggregator;
 use Algolia\SearchBundle\TestApp\Entity\Post;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class AggregatorTest extends BaseTest
 {
@@ -18,7 +19,7 @@ class AggregatorTest extends BaseTest
      */
     protected $entityManager;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -28,27 +29,27 @@ class AggregatorTest extends BaseTest
         $this->entityManager  = $this->get('doctrine')->getManager();
     }
 
-    public function testGetEntities()
+    public function testGetEntities(): void
     {
         $entities = EmptyAggregator::getEntities();
 
-        $this->assertEquals([], $entities);
+        self::assertEquals([], $entities);
     }
 
-    public function testGetEntityClassFromObjectID()
+    public function testGetEntityClassFromObjectID(): void
     {
         $this->expectException(EntityNotFoundInObjectID::class);
         EmptyAggregator::getEntityClassFromObjectID('test');
     }
 
-    public function testConstructor()
+    public function testConstructor(): void
     {
         $this->expectException(InvalidEntityForAggregator::class);
         $post                = new Post();
         $compositeAggregator = new ContentAggregator($post, ['objectId', 'url']);
     }
 
-    public function testAggregatorProxyClass()
+    public function testAggregatorProxyClass(): void
     {
         $post = new Post([
             'id'      => 1,
@@ -64,10 +65,11 @@ class AggregatorTest extends BaseTest
         $proxy             = $this->entityManager->getProxyFactory()->getProxy($postMetadata->getName(), ['id' => 1]);
         $contentAggregator = new ContentAggregator($proxy, ['objectId']);
 
+        /** @var NormalizerInterface $serializer */
         $serializer = $this->get('serializer');
 
         $serializedData = $contentAggregator->normalize($serializer);
-        $this->assertNotEmpty($serializedData);
-        $this->assertEquals('Algolia\SearchBundle\TestApp\Entity\Post::objectId', $serializedData['objectID']);
+        self::assertNotEmpty($serializedData);
+        self::assertEquals('Algolia\SearchBundle\TestApp\Entity\Post::objectId', $serializedData['objectID']);
     }
 }

--- a/tests/TestCase/ClientProxyTest.php
+++ b/tests/TestCase/ClientProxyTest.php
@@ -4,12 +4,13 @@ namespace Algolia\SearchBundle\TestCase;
 
 use Algolia\SearchBundle\BaseTest;
 use ProxyManager\Proxy\ProxyInterface;
+use Symfony\Component\DependencyInjection\Exception\EnvNotFoundException;
 
 class ClientProxyTest extends BaseTest
 {
     private static $values = [];
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         // Unset env variables to make sure Algolia
         // Credentials are only required when the
@@ -30,7 +31,7 @@ class ClientProxyTest extends BaseTest
         unset($_SERVER['ALGOLIA_API_KEY']);
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         putenv('ALGOLIA_APP_ID=' . self::$values['env_id']);
         putenv('ALGOLIA_API_KEY=' . self::$values['env_key']);
@@ -38,18 +39,16 @@ class ClientProxyTest extends BaseTest
         $_SERVER = self::$values['_server'];
     }
 
-    public function testClientIsProxied()
+    public function testClientIsProxied(): void
     {
         $interfaces = class_implements($this->get('search.client'));
 
-        $this->assertTrue(in_array(ProxyInterface::class, $interfaces));
+        self::assertContains(ProxyInterface::class, $interfaces);
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\EnvNotFoundException
-     */
-    public function testProxiedClientFailIfNoEnvVarsFound()
+    public function testProxiedClientFailIfNoEnvVarsFound(): void
     {
+        $this->expectException(EnvNotFoundException::class);
         $this->get('search.client')->listIndices();
     }
 }

--- a/tests/TestCase/CommandsTest.php
+++ b/tests/TestCase/CommandsTest.php
@@ -21,7 +21,7 @@ class CommandsTest extends BaseTest
     protected $platform;
     protected $index;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->searchService = $this->get('search.service');
@@ -41,14 +41,14 @@ class CommandsTest extends BaseTest
         $this->refreshDb($this->application);
     }
 
-    public function cleanUp()
+    public function cleanUp(): void
     {
         $this->searchService->delete(Post::class)->wait();
         $this->searchService->delete(Comment::class)->wait();
         $this->searchService->delete(ContentAggregator::class)->wait();
     }
 
-    public function testSearchClearUnknownIndex()
+    public function testSearchClearUnknownIndex(): void
     {
         $unknownIndexName = 'test';
 
@@ -61,18 +61,18 @@ class CommandsTest extends BaseTest
 
         // Checks output and ensure it failed
         $output = $commandTester->getDisplay();
-        $this->assertContains('No index named ' . $unknownIndexName, $output);
+        self::assertStringContainsString('No index named ' . $unknownIndexName, $output);
         $this->cleanUp();
     }
 
-    public function testSearchClear()
+    public function testSearchClear(): void
     {
         $this->om = $this->get('doctrine')->getManager();
         $this->searchService->index($this->om, $this->createPost(10))->wait();
 
         // Checks that post was created and indexed
         $searchPost = $this->searchService->rawSearch(Post::class);
-        $this->assertCount(1, $searchPost['hits']);
+        self::assertCount(1, $searchPost['hits']);
 
         $command       = $this->application->find('search:clear');
         $commandTester = new CommandTester($command);
@@ -82,11 +82,11 @@ class CommandsTest extends BaseTest
 
         // Checks output
         $output = $commandTester->getDisplay();
-        $this->assertContains('Cleared posts', $output);
+        self::assertStringContainsString('Cleared posts', $output);
         $this->cleanUp();
     }
 
-    public function testSearchImportAggregator()
+    public function testSearchImportAggregator(): void
     {
         $now = new \DateTime();
         $this->connection->insert($this->indexName, [
@@ -114,7 +114,7 @@ class CommandsTest extends BaseTest
 
         // Checks output
         $output = $commandTester->getDisplay();
-        $this->assertContains('Done!', $output);
+        self::assertStringContainsString('Done!', $output);
 
         $iteration      = 0;
         $expectedResult = 3;
@@ -126,7 +126,7 @@ class CommandsTest extends BaseTest
 
         // Ensure posts were imported into contents index
         $searchPost = $this->searchService->rawSearch(ContentAggregator::class);
-        $this->assertCount($expectedResult, $searchPost['hits']);
+        self::assertCount($expectedResult, $searchPost['hits']);
         // clearup table
         $this->connection->executeUpdate($this->platform->getTruncateTableSQL($this->indexName, true));
         $this->cleanUp();
@@ -135,7 +135,7 @@ class CommandsTest extends BaseTest
     /**
      * @testWith [true, false]
      */
-    public function testSearchImport($isAtomic)
+    public function testSearchImport($isAtomic): void
     {
         $now = new \DateTime();
         $this->connection->insert($this->indexName, [
@@ -164,7 +164,7 @@ class CommandsTest extends BaseTest
 
         // Checks output
         $output = $commandTester->getDisplay();
-        $this->assertContains('Done!', $output);
+        self::assertStringContainsString('Done!', $output);
 
         // Ensure posts were imported
         $iteration      = 0;
@@ -175,13 +175,13 @@ class CommandsTest extends BaseTest
             $iteration++;
         } while (count($searchPost['hits']) !== $expectedResult || $iteration < 10);
 
-        $this->assertCount($expectedResult, $searchPost['hits']);
+        self::assertCount($expectedResult, $searchPost['hits']);
         // clearup table
         $this->connection->executeUpdate($this->platform->getTruncateTableSQL($this->indexName, true));
         $this->cleanUp();
     }
 
-    public function testSearchSettingsBackupCommand()
+    public function testSearchSettingsBackupCommand(): void
     {
         $settingsToUpdate = [
             'hitsPerPage'       => 51,
@@ -197,16 +197,16 @@ class CommandsTest extends BaseTest
 
         // Checks output
         $output = $commandTester->getDisplay();
-        $this->assertContains('Saved settings', $output);
+        self::assertStringContainsString('Saved settings', $output);
 
         $settingsFile = $this->getFileName($this->indexName, 'settings');
 
         $settingsFileContent = json_decode(file_get_contents($settingsFile), true);
-        $this->assertContains($settingsToUpdate['hitsPerPage'], $settingsFileContent);
-        $this->assertContains($settingsToUpdate['maxValuesPerFacet'], $settingsFileContent);
+        self::assertStringContainsString($settingsToUpdate['hitsPerPage'], $settingsFileContent['hitsPerPage']);
+        self::assertStringContainsString($settingsToUpdate['maxValuesPerFacet'], $settingsFileContent['maxValuesPerFacet']);
     }
 
-    public function testSearchSettingsPushCommand()
+    public function testSearchSettingsPushCommand(): void
     {
         $settingsToUpdate = [
             'hitsPerPage'       => 50,
@@ -217,8 +217,8 @@ class CommandsTest extends BaseTest
         $settingsFile = $this->getFileName($this->indexName, 'settings');
 
         $settingsFileContent = json_decode(file_get_contents($settingsFile), true);
-        $this->assertNotEquals($settings['hitsPerPage'], $settingsFileContent['hitsPerPage']);
-        $this->assertNotEquals($settings['maxValuesPerFacet'], $settingsFileContent['maxValuesPerFacet']);
+        self::assertNotEquals($settings['hitsPerPage'], $settingsFileContent['hitsPerPage']);
+        self::assertNotEquals($settings['maxValuesPerFacet'], $settingsFileContent['maxValuesPerFacet']);
 
         $command       = $this->application->find('search:settings:push');
         $commandTester = new CommandTester($command);
@@ -229,7 +229,7 @@ class CommandsTest extends BaseTest
 
         // Checks output
         $output = $commandTester->getDisplay();
-        $this->assertContains('Pushed settings', $output);
+        self::assertStringContainsString('Pushed settings', $output);
 
         // check if the settings were imported
         $iteration = 0;
@@ -239,8 +239,8 @@ class CommandsTest extends BaseTest
             $iteration++;
         } while ($newSettings['hitsPerPage'] !== $settingsFileContent['hitsPerPage'] || $iteration < 10);
 
-        $this->assertEquals($newSettings['hitsPerPage'], $settingsFileContent['hitsPerPage']);
-        $this->assertEquals($newSettings['maxValuesPerFacet'], $settingsFileContent['maxValuesPerFacet']);
+        self::assertEquals($newSettings['hitsPerPage'], $settingsFileContent['hitsPerPage']);
+        self::assertEquals($newSettings['maxValuesPerFacet'], $settingsFileContent['maxValuesPerFacet']);
         $this->cleanUp();
     }
 }

--- a/tests/TestCase/ConfigurationTest.php
+++ b/tests/TestCase/ConfigurationTest.php
@@ -13,7 +13,7 @@ class ConfigurationTest extends BaseTest
      * @param mixed $inputConfig
      * @param mixed $expectedConfig
      */
-    public function testConfigurationTree($inputConfig, $expectedConfig)
+    public function testConfigurationTree($inputConfig, $expectedConfig): void
     {
         $configuration = new Configuration();
 
@@ -22,10 +22,10 @@ class ConfigurationTest extends BaseTest
         $normalizedConfig = $node->normalize($inputConfig);
         $finalizedConfig  = $node->finalize($normalizedConfig);
 
-        $this->assertEquals($expectedConfig, $finalizedConfig);
+        self::assertEquals($expectedConfig, $finalizedConfig);
     }
 
-    public function dataTestConfigurationTree()
+    public function dataTestConfigurationTree(): array
     {
         return [
             'test empty config for default value' => [
@@ -60,7 +60,12 @@ class ConfigurationTest extends BaseTest
                     'prefix'  => 'sf_',
                     'indices' => [
                         ['name' => 'posts', 'class' => 'App\Entity\Post', 'index_if' => null],
-                        ['name' => 'tags', 'class' => 'App\Entity\Tag', 'enable_serializer_groups' => true, 'index_if' => null],
+                        [
+                            'name'                     => 'tags',
+                            'class'                    => 'App\Entity\Tag',
+                            'enable_serializer_groups' => true,
+                            'index_if'                 => null,
+                        ],
                     ],
                 ], [
                     'prefix'                   => 'sf_',

--- a/tests/TestCase/EngineTest.php
+++ b/tests/TestCase/EngineTest.php
@@ -10,7 +10,7 @@ class EngineTest extends BaseTest
 {
     protected $engine;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -29,7 +29,7 @@ class EngineTest extends BaseTest
      *
      * @group legacy
      */
-    public function testIndexing()
+    public function testIndexing(): void
     {
         $searchablePost = $this->createSearchablePost();
 
@@ -40,22 +40,22 @@ class EngineTest extends BaseTest
         $result = $this->engine->index($searchablePost, [
             'autoGenerateObjectIDIfNotExist' => true,
         ]);
-        $this->assertArrayHasKey($searchablePost->getIndexName(), $result);
-        $this->assertEquals(1, $result[$searchablePost->getIndexName()]->count());
+        self::assertArrayHasKey($searchablePost->getIndexName(), $result);
+        self::assertEquals(1, $result[$searchablePost->getIndexName()]->count());
 
         // Remove
         $result = $this->engine->remove($searchablePost, [
             'X-Forwarded-For' => '0.0.0.0',
         ]);
-        $this->assertArrayHasKey($searchablePost->getIndexName(), $result);
-        $this->assertEquals(1, $result[$searchablePost->getIndexName()]->count());
+        self::assertArrayHasKey($searchablePost->getIndexName(), $result);
+        self::assertEquals(1, $result[$searchablePost->getIndexName()]->count());
 
         // Update
         $result = $this->engine->index($searchablePost, [
             'createIfNotExists' => true,
         ]);
-        $this->assertArrayHasKey($searchablePost->getIndexName(), $result);
-        $this->assertEquals(1, $result[$searchablePost->getIndexName()]->count());
+        self::assertArrayHasKey($searchablePost->getIndexName(), $result);
+        self::assertEquals(1, $result[$searchablePost->getIndexName()]->count());
         foreach ($result as $indexName => $response) {
             $response->wait();
         }
@@ -68,11 +68,11 @@ class EngineTest extends BaseTest
                 'title',
             ],
         ]);
-        $this->assertArrayHasKey('hits', $result);
-        $this->assertArrayHasKey('nbHits', $result);
-        $this->assertArrayHasKey('page', $result);
-        $this->assertArrayHasKey('title', $result['hits'][0]);
-        $this->assertArrayNotHasKey('content', $result['hits'][0]);
+        self::assertArrayHasKey('hits', $result);
+        self::assertArrayHasKey('nbHits', $result);
+        self::assertArrayHasKey('page', $result);
+        self::assertArrayHasKey('title', $result['hits'][0]);
+        self::assertArrayNotHasKey('content', $result['hits'][0]);
 
         // Search IDs
         $result = $this->engine->searchIds('This should not have results', $searchablePost->getIndexName(), [
@@ -82,24 +82,24 @@ class EngineTest extends BaseTest
                 'title',
             ],
         ]);
-        $this->assertEmpty($result);
+        self::assertEmpty($result);
 
         // Count
         $result = $this->engine->count('', $searchablePost->getIndexName(), ['tagFilters' => 'test']);
-        $this->assertEquals(0, $result);
+        self::assertEquals(0, $result);
         $result = $this->engine->count('This should not have results', $searchablePost->getIndexName(), []);
-        $this->assertEquals(0, $result);
+        self::assertEquals(0, $result);
 
         // Cleanup
         $result = $this->engine->clear($searchablePost->getIndexName(), []);
-        $this->assertInstanceOf(IndexingResponse::class, $result);
+        self::assertInstanceOf(IndexingResponse::class, $result);
 
         // Delete index
         $result = $this->engine->delete($searchablePost->getIndexName(), []);
-        $this->assertInstanceOf(IndexingResponse::class, $result);
+        self::assertInstanceOf(IndexingResponse::class, $result);
     }
 
-    public function testIndexingEmptyEntity()
+    public function testIndexingEmptyEntity(): void
     {
         $searchableImage = $this->createSearchableImage();
         $requestOptions  = [];
@@ -109,21 +109,21 @@ class EngineTest extends BaseTest
 
         // Index
         $result = $this->engine->index($searchableImage, $requestOptions);
-        $this->assertEmpty($result);
+        self::assertEmpty($result);
 
         // Remove
         $result = $this->engine->remove($searchableImage, $requestOptions);
-        $this->assertEmpty($result);
+        self::assertEmpty($result);
 
         // Update
         $result = $this->engine->index($searchableImage, $requestOptions);
-        $this->assertEmpty($result);
+        self::assertEmpty($result);
 
         // Search
         try {
             $this->engine->search('query', $searchableImage->getIndexName(), $requestOptions);
         } catch (\Exception $e) {
-            $this->assertInstanceOf('Algolia\AlgoliaSearch\Exceptions\NotFoundException', $e);
+            self::assertInstanceOf('Algolia\AlgoliaSearch\Exceptions\NotFoundException', $e);
         }
     }
 }

--- a/tests/TestCase/EntityProxyTest.php
+++ b/tests/TestCase/EntityProxyTest.php
@@ -58,12 +58,26 @@ class EntityProxyTest extends BaseTest
         self::assertEquals('Algolia\\SearchBundle\\TestApp\\Entity\\Comment', ClassInfo::getClass($comment));
     }
 
-    public function testEntityIsProxied(): void
+    public function testEntityIsProxiedWithOPM(): void
     {
         $factory = new \ProxyManager\Factory\NullObjectFactory();
         $proxy   = $factory->createProxy(\Algolia\SearchBundle\TestApp\Entity\Comment::class);
 
         self::assertStringStartsWith('ProxyManagerGeneratedProxy\\__PM__\\Algolia\\SearchBundle\\TestApp\\Entity\\Comment', get_class($proxy));
+        self::assertEquals('Algolia\\SearchBundle\\TestApp\\Entity\\Comment', ClassInfo::getClass($proxy));
+    }
+
+    public function testEntityIsProxiedWithDP(): void
+    {
+        /** @var \Doctrine\ORM\EntityManagerInterface $entityManager */
+        $entityManager = $this->get('doctrine')->getManager();
+
+        $metadata = $entityManager->getClassMetadata(\Algolia\SearchBundle\TestApp\Entity\Comment::class);
+        $entityManager->getProxyFactory()->generateProxyClasses([$metadata]);
+
+        $proxy = $entityManager->getProxyFactory()->getProxy($metadata->getName(), ['id' => 1]);
+
+        self::assertStringStartsWith('Proxies\\__CG__\Algolia\\SearchBundle\\TestApp\\Entity\\Comment', get_class($proxy));
         self::assertEquals('Algolia\\SearchBundle\\TestApp\\Entity\\Comment', ClassInfo::getClass($proxy));
     }
 }

--- a/tests/TestCase/EntityProxyTest.php
+++ b/tests/TestCase/EntityProxyTest.php
@@ -19,9 +19,16 @@ class EntityProxyTest extends BaseTest
         self::$values = [
             'env_id'  => getenv('ALGOLIA_APP_ID'),
             'env_key' => getenv('ALGOLIA_API_KEY'),
-            '_env'    => $_ENV,
-            '_server' => $_SERVER,
         ];
+
+        foreach (['id' => 'ALGOLIA_APP_ID', 'key' => 'ALGOLIA_API_KEY'] as $key => $item) {
+            if (isset($_ENV[$item])) {
+                self::$values['_env_' . $key] = $_ENV[$item];
+            }
+            if (isset($_SERVER[$item])) {
+                self::$values['_server_' . $key] = $_SERVER[$item];
+            }
+        }
 
         putenv('ALGOLIA_APP_ID');
         putenv('ALGOLIA_API_KEY');
@@ -35,8 +42,14 @@ class EntityProxyTest extends BaseTest
     {
         putenv('ALGOLIA_APP_ID=' . self::$values['env_id']);
         putenv('ALGOLIA_API_KEY=' . self::$values['env_key']);
-        $_ENV    = self::$values['_env'];
-        $_SERVER = self::$values['_server'];
+        foreach (['id' => 'ALGOLIA_APP_ID', 'key' => 'ALGOLIA_API_KEY'] as $key => $item) {
+            if (isset(self::$values['_env_' . $key])) {
+                $_ENV[$item] = self::$values['_env_' . $key];
+            }
+            if (isset(self::$values['_server_' . $key])) {
+                $_SERVER[$item] = self::$values['_server_' . $key];
+            }
+        }
     }
 
     public function testEntityIsNotProxied(): void

--- a/tests/TestCase/EntityProxyTest.php
+++ b/tests/TestCase/EntityProxyTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Algolia\SearchBundle\TestCase;
+
+use Algolia\SearchBundle\BaseTest;
+use Algolia\SearchBundle\TestApp\Entity\Comment;
+use Algolia\SearchBundle\Util\ClassInfo;
+
+class EntityProxyTest extends BaseTest
+{
+    private static $values = [];
+
+    public static function setUpBeforeClass()
+    {
+        // Unset env variables to make sure Algolia
+        // Credentials are only required when the
+        // client is used. Save them to restore them after.
+        // See: https://github.com/algolia/search-bundle/issues/241
+        self::$values = [
+            'env_id'  => getenv('ALGOLIA_APP_ID'),
+            'env_key' => getenv('ALGOLIA_API_KEY'),
+            '_env'    => $_ENV,
+            '_server' => $_SERVER,
+        ];
+
+        putenv('ALGOLIA_APP_ID');
+        putenv('ALGOLIA_API_KEY');
+        unset($_ENV['ALGOLIA_APP_ID']);
+        unset($_ENV['ALGOLIA_API_KEY']);
+        unset($_SERVER['ALGOLIA_APP_ID']);
+        unset($_SERVER['ALGOLIA_API_KEY']);
+    }
+
+    public static function tearDownAfterClass()
+    {
+        putenv('ALGOLIA_APP_ID=' . self::$values['env_id']);
+        putenv('ALGOLIA_API_KEY=' . self::$values['env_key']);
+        $_ENV    = self::$values['_env'];
+        $_SERVER = self::$values['_server'];
+    }
+
+    public function testEntityIsNotProxied()
+    {
+        $comment = new Comment();
+        $this->assertEquals('Algolia\\SearchBundle\\TestApp\\Entity\\Comment', ClassInfo::getClass($comment));
+    }
+
+    public function testEntityIsProxied()
+    {
+        $factory = new \ProxyManager\Factory\NullObjectFactory();
+        $proxy   = $factory->createProxy(\Algolia\SearchBundle\TestApp\Entity\Comment::class);
+
+        $this->assertStringStartsWith('ProxyManagerGeneratedProxy\\__PM__\\Algolia\\SearchBundle\\TestApp\\Entity\\Comment', get_class($proxy));
+        $this->assertEquals('Algolia\\SearchBundle\\TestApp\\Entity\\Comment', ClassInfo::getClass($proxy));
+    }
+}

--- a/tests/TestCase/EntityProxyTest.php
+++ b/tests/TestCase/EntityProxyTest.php
@@ -10,7 +10,7 @@ class EntityProxyTest extends BaseTest
 {
     private static $values = [];
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         // Unset env variables to make sure Algolia
         // Credentials are only required when the
@@ -31,7 +31,7 @@ class EntityProxyTest extends BaseTest
         unset($_SERVER['ALGOLIA_API_KEY']);
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         putenv('ALGOLIA_APP_ID=' . self::$values['env_id']);
         putenv('ALGOLIA_API_KEY=' . self::$values['env_key']);
@@ -39,18 +39,18 @@ class EntityProxyTest extends BaseTest
         $_SERVER = self::$values['_server'];
     }
 
-    public function testEntityIsNotProxied()
+    public function testEntityIsNotProxied(): void
     {
         $comment = new Comment();
-        $this->assertEquals('Algolia\\SearchBundle\\TestApp\\Entity\\Comment', ClassInfo::getClass($comment));
+        self::assertEquals('Algolia\\SearchBundle\\TestApp\\Entity\\Comment', ClassInfo::getClass($comment));
     }
 
-    public function testEntityIsProxied()
+    public function testEntityIsProxied(): void
     {
         $factory = new \ProxyManager\Factory\NullObjectFactory();
         $proxy   = $factory->createProxy(\Algolia\SearchBundle\TestApp\Entity\Comment::class);
 
-        $this->assertStringStartsWith('ProxyManagerGeneratedProxy\\__PM__\\Algolia\\SearchBundle\\TestApp\\Entity\\Comment', get_class($proxy));
-        $this->assertEquals('Algolia\\SearchBundle\\TestApp\\Entity\\Comment', ClassInfo::getClass($proxy));
+        self::assertStringStartsWith('ProxyManagerGeneratedProxy\\__PM__\\Algolia\\SearchBundle\\TestApp\\Entity\\Comment', get_class($proxy));
+        self::assertEquals('Algolia\\SearchBundle\\TestApp\\Entity\\Comment', ClassInfo::getClass($proxy));
     }
 }

--- a/tests/TestCase/SearchServiceTest.php
+++ b/tests/TestCase/SearchServiceTest.php
@@ -16,36 +16,36 @@ class SearchServiceTest extends BaseTest
     protected $searchService;
     protected $entityManager;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->searchService  = $this->get('search.service');
         $this->entityManager  = $this->get('doctrine')->getManager();
     }
 
-    public function cleanUp()
+    public function cleanUp(): void
     {
         $this->searchService->delete(Post::class)->wait();
         $this->searchService->delete(Comment::class)->wait();
         $this->searchService->delete(ContentAggregator::class)->wait();
     }
 
-    public function testIsSearchableMethod()
+    public function testIsSearchableMethod(): void
     {
-        $this->assertTrue($this->searchService->isSearchable(Post::class));
-        $this->assertTrue($this->searchService->isSearchable(Comment::class));
-        $this->assertFalse($this->searchService->isSearchable(BaseTest::class));
-        $this->assertFalse($this->searchService->isSearchable(Image::class));
-        $this->assertTrue($this->searchService->isSearchable(ContentAggregator::class));
-        $this->assertTrue($this->searchService->isSearchable(Tag::class));
-        $this->assertTrue($this->searchService->isSearchable(Link::class));
+        self::assertTrue($this->searchService->isSearchable(Post::class));
+        self::assertTrue($this->searchService->isSearchable(Comment::class));
+        self::assertFalse($this->searchService->isSearchable(BaseTest::class));
+        self::assertFalse($this->searchService->isSearchable(Image::class));
+        self::assertTrue($this->searchService->isSearchable(ContentAggregator::class));
+        self::assertTrue($this->searchService->isSearchable(Tag::class));
+        self::assertTrue($this->searchService->isSearchable(Link::class));
         $this->cleanUp();
     }
 
-    public function testGetSearchableEntities()
+    public function testGetSearchableEntities(): void
     {
         $result = $this->searchService->getSearchables();
-        $this->assertEquals([
+        self::assertEquals([
             Post::class,
             Comment::class,
             ContentAggregator::class,
@@ -55,18 +55,16 @@ class SearchServiceTest extends BaseTest
         $this->cleanUp();
     }
 
-    /**
-     * @expectedException \Exception
-     */
-    public function testExceptionIfNoId()
+    public function testExceptionIfNoId(): void
     {
+        $this->expectException(\Exception::class);
         $this->entityManager = $this->get('doctrine')->getManager();
 
         $this->searchService->index($this->entityManager, new Post());
         $this->cleanUp();
     }
 
-    public function testIndexedDataAreSearchable()
+    public function testIndexedDataAreSearchable(): void
     {
         $posts = [];
         for ($i = 0; $i < 3; $i++) {
@@ -85,29 +83,29 @@ class SearchServiceTest extends BaseTest
 
         // RawSearch
         $searchPost = $this->searchService->rawSearch(Post::class);
-        $this->assertCount(4, $searchPost['hits']);
+        self::assertCount(4, $searchPost['hits']);
         $searchPost = $this->searchService->rawSearch(Post::class, '', [
             'page'        => 0,
             'hitsPerPage' => 1,
         ]);
-        $this->assertCount(1, $searchPost['hits']);
+        self::assertCount(1, $searchPost['hits']);
 
         $searchPostEmpty = $this->searchService->rawSearch(Post::class, 'with no result');
-        $this->assertCount(0, $searchPostEmpty['hits']);
+        self::assertCount(0, $searchPostEmpty['hits']);
 
         $searchComment = $this->searchService->rawSearch(Comment::class);
-        $this->assertCount(1, $searchComment['hits']);
+        self::assertCount(1, $searchComment['hits']);
 
         $searchPost = $this->searchService->rawSearch(ContentAggregator::class, 'test');
-        $this->assertCount(4, $searchPost['hits']);
+        self::assertCount(4, $searchPost['hits']);
 
         $searchPost = $this->searchService->rawSearch(ContentAggregator::class, 'Comment content');
-        $this->assertCount(1, $searchPost['hits']);
+        self::assertCount(1, $searchPost['hits']);
 
         // Count
-        $this->assertEquals(4, $this->searchService->count(Post::class, 'test'));
-        $this->assertEquals(1, $this->searchService->count(Comment::class, 'content'));
-        $this->assertEquals(6, $this->searchService->count(ContentAggregator::class));
+        self::assertEquals(4, $this->searchService->count(Post::class, 'test'));
+        self::assertEquals(1, $this->searchService->count(Comment::class, 'content'));
+        self::assertEquals(6, $this->searchService->count(ContentAggregator::class));
 
         // Cleanup
         $this->searchService->delete(Post::class);
@@ -116,7 +114,7 @@ class SearchServiceTest extends BaseTest
         $this->cleanUp();
     }
 
-    public function testIndexedDataCanBeRemoved()
+    public function testIndexedDataCanBeRemoved(): void
     {
         $posts = [];
         for ($i = 0; $i < 3; $i++) {
@@ -136,31 +134,31 @@ class SearchServiceTest extends BaseTest
         $this->searchService->remove($this->entityManager, end($posts))->wait();
 
         // Expects 2 posts and 1 comment.
-        $this->assertEquals(2, $this->searchService->count(Post::class));
-        $this->assertEquals(1, $this->searchService->count(Comment::class));
+        self::assertEquals(2, $this->searchService->count(Post::class));
+        self::assertEquals(1, $this->searchService->count(Comment::class));
 
         // The content aggregator expects 2 + 1 + 1.
-        $this->assertEquals(4, $this->searchService->count(ContentAggregator::class));
+        self::assertEquals(4, $this->searchService->count(ContentAggregator::class));
 
         // Remove the only comment that exists.
         $this->searchService->remove($this->entityManager, $comment)->wait();
 
         // Expects 2 posts and 0 comments.
-        $this->assertEquals(2, $this->searchService->count(Post::class));
-        $this->assertEquals(0, $this->searchService->count(Comment::class));
+        self::assertEquals(2, $this->searchService->count(Post::class));
+        self::assertEquals(0, $this->searchService->count(Comment::class));
 
         // The content aggregator expects 2 + 0 + 1.
-        $this->assertEquals(3, $this->searchService->count(ContentAggregator::class));
+        self::assertEquals(3, $this->searchService->count(ContentAggregator::class));
 
         // Remove the only image that exists.
         $this->searchService->remove($this->entityManager, $image)->wait();
 
         // The content aggregator expects 2 + 0 + 0.
-        $this->assertEquals(2, $this->searchService->count(ContentAggregator::class));
+        self::assertEquals(2, $this->searchService->count(ContentAggregator::class));
         $this->cleanUp();
     }
 
-    public function testRawSearchRawContent()
+    public function testRawSearchRawContent(): void
     {
         $postIndexed = $this->createPost(10);
         $postIndexed->setTitle('Foo Bar');
@@ -169,15 +167,15 @@ class SearchServiceTest extends BaseTest
 
         // Using entity.
         $results = $this->searchService->rawSearch(Post::class, 'Foo Bar');
-        $this->assertEquals($results['hits'][0]['title'], $postIndexed->getTitle());
+        self::assertEquals($results['hits'][0]['title'], $postIndexed->getTitle());
 
         // Using aggregator.
         $results = $this->searchService->rawSearch(ContentAggregator::class, 'Foo Bar');
-        $this->assertEquals($results['hits'][0]['title'], $postIndexed->getTitle());
+        self::assertEquals($results['hits'][0]['title'], $postIndexed->getTitle());
         $this->cleanUp();
     }
 
-    public function testIndexIfCondition()
+    public function testIndexIfCondition(): void
     {
         $posts = [];
         for ($i = 0; $i < 3; $i++) {
@@ -193,15 +191,13 @@ class SearchServiceTest extends BaseTest
         $this->searchService->index($this->entityManager, $posts)->wait();
 
         // The content aggregator expects 3 ( not 4, because of the index_if condition ).
-        $this->assertEquals(3, $this->searchService->count(ContentAggregator::class));
+        self::assertEquals(3, $this->searchService->count(ContentAggregator::class));
         $this->cleanUp();
     }
 
-    /**
-     * @expectedException \Exception
-     */
-    public function testClearUnsearchableEntity()
+    public function testClearUnsearchableEntity(): void
     {
+        $this->expectException(\Exception::class);
         $image = $this->createSearchableImage();
 
         $this->searchService->index($this->entityManager, [$image]);
@@ -209,10 +205,10 @@ class SearchServiceTest extends BaseTest
         $this->cleanUp();
     }
 
-    public function testShouldNotBeIndexed()
+    public function testShouldNotBeIndexed(): void
     {
         $link = new Link();
-        $this->assertFalse($this->searchService->shouldBeIndexed($link));
+        self::assertFalse($this->searchService->shouldBeIndexed($link));
         $this->cleanUp();
     }
 }

--- a/tests/TestCase/SerializationTest.php
+++ b/tests/TestCase/SerializationTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Serializer\Serializer;
 
 class SerializationTest extends BaseTest
 {
-    public function testSerializerHasRequiredNormalizers()
+    public function testSerializerHasRequiredNormalizers(): void
     {
         $serializer = $this->get('serializer');
 
@@ -24,17 +24,17 @@ class SerializationTest extends BaseTest
         $normalizersProperty->setAccessible(true);
         $normalizers = $normalizersProperty->getValue($serializer);
 
-        $classes = array_map(function ($value) {
+        $classes = array_map(static function ($value) {
             return get_class($value);
         }, $normalizers);
 
-        $this->assertContains('ObjectNormalizer', end($classes));
-        $this->assertContains(CustomNormalizer::class, $classes);
-        $this->assertContains(CommentNormalizer::class, $classes);
-        $this->assertGreaterThan(3, count($classes));
+        self::assertStringContainsString('ObjectNormalizer', end($classes));
+        self::assertContains(CustomNormalizer::class, $classes);
+        self::assertContains(CommentNormalizer::class, $classes);
+        self::assertGreaterThan(3, count($classes));
     }
 
-    public function testSimpleEntityToSearchableArray()
+    public function testSimpleEntityToSearchableArray(): void
     {
         $datetime       = new \DateTime();
         $dateSerializer = new Serializer([new DateTimeNormalizer()]);
@@ -75,10 +75,10 @@ class SerializationTest extends BaseTest
             ],
         ];
 
-        $this->assertEquals($expected, $searchablePost->getSearchableArray());
+        self::assertEquals($expected, $searchablePost->getSearchableArray());
     }
 
-    public function testEntityWithAnnotationsToSearchableArray()
+    public function testEntityWithAnnotationsToSearchableArray(): void
     {
         $datetime       = new \DateTime();
         $dateSerializer = new Serializer([new DateTimeNormalizer()]);
@@ -112,10 +112,10 @@ class SerializationTest extends BaseTest
             'publishedAt' => $serializedDateTime,
         ];
 
-        $this->assertEquals($expected, $searchablePost->getSearchableArray());
+        self::assertEquals($expected, $searchablePost->getSearchableArray());
     }
 
-    public function testNormalizableEntityToSearchableArray()
+    public function testNormalizableEntityToSearchableArray(): void
     {
         $datetime       = new \DateTime();
         $dateSerializer = new Serializer([new DateTimeNormalizer()]);
@@ -144,10 +144,10 @@ class SerializationTest extends BaseTest
             'publishedAt' => $serializedDateTime,
         ];
 
-        $this->assertEquals($expected, $searchableTag->getSearchableArray());
+        self::assertEquals($expected, $searchableTag->getSearchableArray());
     }
 
-    public function testDedicatedNormalizer()
+    public function testDedicatedNormalizer(): void
     {
         $comment = new Comment([
             'id'      => 99,
@@ -166,10 +166,10 @@ class SerializationTest extends BaseTest
             'post_title' => 'Another super post',
         ];
 
-        $this->assertEquals($expected, $searchableComment->getSearchableArray());
+        self::assertEquals($expected, $searchableComment->getSearchableArray());
     }
 
-    public function testSimpleEntityWithJMSSerializer()
+    public function testSimpleEntityWithJMSSerializer(): void
     {
         $datetime = new \DateTime();
         // The format is defined in the framework configuration (see tests/config/config.yml)
@@ -209,6 +209,6 @@ class SerializationTest extends BaseTest
             ],
         ];
 
-        $this->assertEquals($expected, $searchablePost->getSearchableArray());
+        self::assertEquals($expected, $searchablePost->getSearchableArray());
     }
 }

--- a/tests/TestCase/SettingsTest.php
+++ b/tests/TestCase/SettingsTest.php
@@ -17,7 +17,7 @@ class SettingsTest extends BaseTest
     private $configIndexes;
     private $indexName;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -27,7 +27,7 @@ class SettingsTest extends BaseTest
         $this->indexName       = 'posts';
     }
 
-    public function cleanUp()
+    public function cleanUp(): void
     {
         $this->get('search.service')->delete(Post::class)->wait();
     }
@@ -35,7 +35,7 @@ class SettingsTest extends BaseTest
     /**
      * @group internal
      */
-    public function testBackup()
+    public function testBackup(): void
     {
         $this->rrmdir($this->get('search.service')->getConfiguration()['settingsDirectory']);
         $settingsToUpdate = [
@@ -47,21 +47,21 @@ class SettingsTest extends BaseTest
 
         $message = $this->settingsManager->backup(['indices' => [$this->indexName]]);
 
-        $this->assertContains('Saved settings for', $message[0]);
-        $this->assertFileExists($this->getFileName($this->indexName, 'settings'));
+        self::assertStringContainsString('Saved settings for', $message[0]);
+        self::assertFileExists($this->getFileName($this->indexName, 'settings'));
 
         $savedSettings = json_decode(file_get_contents(
             $this->getFileName($this->indexName, 'settings')
         ), true);
 
-        $this->assertEquals($settingsToUpdate['hitsPerPage'], $savedSettings['hitsPerPage']);
-        $this->assertEquals($settingsToUpdate['maxValuesPerFacet'], $savedSettings['maxValuesPerFacet']);
+        self::assertEquals($settingsToUpdate['hitsPerPage'], $savedSettings['hitsPerPage']);
+        self::assertEquals($settingsToUpdate['maxValuesPerFacet'], $savedSettings['maxValuesPerFacet']);
     }
 
     /**
      * @group internal
      */
-    public function testBackupWithoutIndices()
+    public function testBackupWithoutIndices(): void
     {
         $this->rrmdir($this->get('search.service')->getConfiguration()['settingsDirectory']);
         $settingsToUpdate = [
@@ -76,24 +76,24 @@ class SettingsTest extends BaseTest
 
         $message = $this->settingsManager->backup(['indices' => []]);
 
-        $this->assertContains('Saved settings for', $message[0]);
+        self::assertStringContainsString('Saved settings for', $message[0]);
 
         foreach ($this->configIndexes as $indexName => $configIndex) {
-            $this->assertFileExists($this->getFileName($this->indexName, 'settings'));
+            self::assertFileExists($this->getFileName($this->indexName, 'settings'));
 
             $savedSettings = json_decode(file_get_contents(
                 $this->getFileName($indexName, 'settings')
             ), true);
 
-            $this->assertEquals($settingsToUpdate['hitsPerPage'], $savedSettings['hitsPerPage']);
-            $this->assertEquals($settingsToUpdate['maxValuesPerFacet'], $savedSettings['maxValuesPerFacet']);
+            self::assertEquals($settingsToUpdate['hitsPerPage'], $savedSettings['hitsPerPage']);
+            self::assertEquals($settingsToUpdate['maxValuesPerFacet'], $savedSettings['maxValuesPerFacet']);
         }
     }
 
     /**
      * @depends testBackup
      */
-    public function testPush()
+    public function testPush(): void
     {
         $settingsToUpdate = [
             'hitsPerPage'       => 12,
@@ -104,7 +104,7 @@ class SettingsTest extends BaseTest
 
         $message = $this->settingsManager->push(['indices' => [$this->indexName]]);
 
-        $this->assertContains('Pushed settings for', $message[0]);
+        self::assertStringContainsString('Pushed settings for', $message[0]);
 
         $savedSettings = json_decode(file_get_contents(
             $this->getFileName($this->indexName, 'settings')
@@ -113,8 +113,8 @@ class SettingsTest extends BaseTest
         for ($i = 0; $i < 5; $i++) {
             sleep(1);
             $settings = $index->getSettings();
-            if (12 != $settings['hitsPerPage']) {
-                $this->assertEquals($savedSettings, $settings);
+            if (12 !== $settings['hitsPerPage']) {
+                self::assertEquals($savedSettings, $settings);
             }
         }
     }
@@ -122,7 +122,7 @@ class SettingsTest extends BaseTest
     /**
      * @depends testBackupWithoutIndices
      */
-    public function testPushWithoutIndices()
+    public function testPushWithoutIndices(): void
     {
         $settingsToUpdate = [
             'hitsPerPage'       => 12,
@@ -136,7 +136,7 @@ class SettingsTest extends BaseTest
 
         $message = $this->settingsManager->push(['indices' => []]);
 
-        $this->assertContains('Pushed settings for', $message[0]);
+        self::assertStringContainsString('Pushed settings for', $message[0]);
 
         foreach ($this->configIndexes as $indexName => $configIndex) {
             $savedSettings = json_decode(file_get_contents(
@@ -146,8 +146,8 @@ class SettingsTest extends BaseTest
             for ($i = 0; $i < 5; $i++) {
                 sleep(1);
                 $settings = $index->getSettings();
-                if (12 != $settings['hitsPerPage']) {
-                    $this->assertEquals($savedSettings, $settings);
+                if (12 !== $settings['hitsPerPage']) {
+                    self::assertEquals($savedSettings, $settings);
                 }
             }
         }
@@ -157,14 +157,14 @@ class SettingsTest extends BaseTest
     /**
      * @see https://www.php.net/rmdir
      */
-    private function rrmdir($dir)
+    private function rrmdir(string $dir): void
     {
         if (is_dir($dir)) {
             $objects = scandir($dir);
             foreach ($objects as $object) {
-                if ($object != '.' && $object != '..') {
+                if ($object !== '.' && $object !== '..') {
                     if (is_dir($dir . '/' . $object)) {
-                        rrmdir($dir . '/' . $object);
+                        $this->rrmdir($dir . '/' . $object);
                     } else {
                         unlink($dir . '/' . $object);
                     }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | yes
| BC breaks?        | yes     
| Need Doc update   | yes


## Describe your change

- Add Symfony 5.2 support (requires `symfony/doctrine-bridge:5.2`-> `doctrine/persistence:^2`)
- Migrate from `doctrine/common` (deprecated) to `doctrine/*` components
- Dropping support for PHP < 7.1 (`doctrine/event-manager` and `doctrine/persistence`) (EOL for PHP 7.1 was in 2019)

## What problem is this fixing?

- Symfony 5.2 support
