### PR TITLE
Fix #347

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -13,5 +13,4 @@ parameters:
         - '#(Method|Function|Constructor).*has parameter.*with.*default value.#'
         - '#Class Symfony\\Component\\Config\\Definition\\Builder\\TreeBuilder constructor#'
         - '#Call to an undefined method Symfony\\Component\\Config\\Definition\\Builder\\TreeBuilder::root\(\).#'
-        - '#Call to an undefined method Doctrine\\Persistence\\ObjectRepository::clear\(\).#'
         - '#Class Algolia\\SearchBundle\\Services\\NullSearchService is neither abstract nor final.#'

--- a/src/Command/SearchImportCommand.php
+++ b/src/Command/SearchImportCommand.php
@@ -116,10 +116,10 @@ EOT
                     }
 
                     $page++;
-                    $repository->clear();
+                    $manager->clear();
                 } while (count($entities) >= $config['batchSize']);
 
-                $repository->clear();
+                $manager->clear();
             }
 
             if ($shouldDoAtomicReindex && isset($indexName)) {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | Fix #347 
| Need Doc update   | yes


## Describe your change

`EntityRepository::clear()` and `EntityManager::clear($className)` are deprecated (due to side-effects).

We can call `EntityManager::clear()` as we do only `select` queries.

Inspired by [ocramius/doctrine-batch-utils](https://github.com/Ocramius/DoctrineBatchUtils#current-features).

## What problem is this fixing?

Fix #347