### PR TITLE
fix: do waitTask on all tasks before moving index

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,9 @@
         "algolia/algoliasearch-client-php": "^3.0",
         "doctrine/event-manager": "^1.1",
         "doctrine/persistence": "^2.1",
-        "symfony/filesystem": "^4.0 || ^5.0",
-        "symfony/property-access": "^4.0 || ^5.0",
-        "symfony/serializer": "^4.0 || ^5.0"
+        "symfony/filesystem": "^3.4 || ^4.0 || ^5.0",
+        "symfony/property-access": "^3.4 || ^4.0 || ^5.0",
+        "symfony/serializer": "^3.4 || ^4.0 || ^5.0"
     },
     "autoload": {
         "psr-4": {
@@ -38,10 +38,10 @@
         "jms/serializer-bundle": "^3.0",
         "ocramius/proxy-manager": "*",
         "phpunit/phpunit": "^8.5 || ^9.0",
-        "symfony/framework-bundle": "^4.0 || ^5.0",
-        "symfony/phpunit-bridge": "^4.0 || ^5.0",
-        "symfony/proxy-manager-bridge": "*",
-        "symfony/yaml": "^4.0 || ^5.0",
+        "symfony/framework-bundle": "^3.5 || ^4.0 || ^5.0",
+        "symfony/phpunit-bridge": "^3.5 || ^4.0 || ^5.0",
+        "symfony/proxy-manager-bridge": "^4.0",
+        "symfony/yaml": "^3.5 || ^4.0 || ^5.0",
         "friendsofphp/php-cs-fixer": "^2.15",
         "roave/security-advisories": "dev-master"
     },

--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,9 @@
         "algolia/algoliasearch-client-php": "^3.0",
         "doctrine/event-manager": "^1.1",
         "doctrine/persistence": "^2.1",
-        "symfony/filesystem": "^3.4 || ^4.0 || ^5.0",
-        "symfony/property-access": "^3.4 || ^4.0 || ^5.0",
-        "symfony/serializer": "^3.4 || ^4.0 || ^5.0"
+        "symfony/filesystem": "^4.0 || ^5.0",
+        "symfony/property-access": "^4.0 || ^5.0",
+        "symfony/serializer": "^4.0 || ^5.0"
     },
     "autoload": {
         "psr-4": {
@@ -38,10 +38,10 @@
         "jms/serializer-bundle": "^3.0",
         "ocramius/proxy-manager": "*",
         "phpunit/phpunit": "^8.5 || ^9.0",
-        "symfony/framework-bundle": "^3.4 || ^4.0 || ^5.0",
-        "symfony/phpunit-bridge": "^3.4 || ^4.0 || ^5.0",
+        "symfony/framework-bundle": "^4.0 || ^5.0",
+        "symfony/phpunit-bridge": "^4.0 || ^5.0",
         "symfony/proxy-manager-bridge": "^4.0",
-        "symfony/yaml": "^3.4 || ^4.0 || ^5.0",
+        "symfony/yaml": "^4.0 || ^5.0",
         "friendsofphp/php-cs-fixer": "^2.15",
         "roave/security-advisories": "dev-master"
     },

--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,9 @@
         "algolia/algoliasearch-client-php": "^3.0",
         "doctrine/event-manager": "^1.1",
         "doctrine/persistence": "^2.1",
-        "symfony/filesystem": "^3.4 || ^4.0 || ^5.0",
-        "symfony/property-access": "^3.4 || ^4.0 || ^5.0",
-        "symfony/serializer": "^3.4 || ^4.0 || ^5.0"
+        "symfony/filesystem": "^4.0 || ^5.0",
+        "symfony/property-access": "^4.0 || ^5.0",
+        "symfony/serializer": "^4.0 || ^5.0"
     },
     "autoload": {
         "psr-4": {
@@ -38,10 +38,10 @@
         "jms/serializer-bundle": "^3.0",
         "ocramius/proxy-manager": "*",
         "phpunit/phpunit": "^8.5 || ^9.0",
-        "symfony/framework-bundle": "^3.4 || ^4.0 || ^5.0",
-        "symfony/phpunit-bridge": "^3.4 || ^4.0 || ^5.0",
+        "symfony/framework-bundle": "^4.0 || ^5.0",
+        "symfony/phpunit-bridge": "^4.0 || ^5.0",
         "symfony/proxy-manager-bridge": "*",
-        "symfony/yaml": "^3.4 || ^4.0 || ^5.0",
+        "symfony/yaml": "^4.0 || ^5.0",
         "friendsofphp/php-cs-fixer": "^2.15",
         "roave/security-advisories": "dev-master"
     },

--- a/composer.json
+++ b/composer.json
@@ -38,10 +38,10 @@
         "jms/serializer-bundle": "^3.0",
         "ocramius/proxy-manager": "*",
         "phpunit/phpunit": "^8.5 || ^9.0",
-        "symfony/framework-bundle": "^3.5 || ^4.0 || ^5.0",
-        "symfony/phpunit-bridge": "^3.5 || ^4.0 || ^5.0",
+        "symfony/framework-bundle": "^3.4 || ^4.0 || ^5.0",
+        "symfony/phpunit-bridge": "^3.4 || ^4.0 || ^5.0",
         "symfony/proxy-manager-bridge": "^4.0",
-        "symfony/yaml": "^3.5 || ^4.0 || ^5.0",
+        "symfony/yaml": "^3.4 || ^4.0 || ^5.0",
         "friendsofphp/php-cs-fixer": "^2.15",
         "roave/security-advisories": "dev-master"
     },

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,6 @@
         "doctrine/orm": "^2.5",
         "friendsofphp/php-cs-fixer": "^2.15",
         "jms/serializer-bundle": "^3.0",
-        "laminas/laminas-zendframework-bridge": "^1.4",
         "friendsofphp/proxy-manager-lts": "*",
         "phpunit/phpunit": "^8.5 || ^9.0",
         "roave/security-advisories": "dev-master",

--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,9 @@
         "algolia/algoliasearch-client-php": "^3.0",
         "doctrine/event-manager": "^1.1",
         "doctrine/persistence": "^2.1",
-        "symfony/filesystem": "^4.0 || ^5.0",
-        "symfony/property-access": "^4.0 || ^5.0",
-        "symfony/serializer": "^4.0 || ^5.0"
+        "symfony/filesystem": "^3.4 || ^4.0 || ^5.0",
+        "symfony/property-access": "^3.4 || ^4.0 || ^5.0",
+        "symfony/serializer": "^3.4 || ^4.0 || ^5.0"
     },
     "autoload": {
         "psr-4": {
@@ -40,9 +40,9 @@
         "friendsofphp/proxy-manager-lts": "*",
         "phpunit/phpunit": "^8.5 || ^9.0",
         "roave/security-advisories": "dev-master",
-        "symfony/framework-bundle": "^4.0 || ^5.0",
-        "symfony/phpunit-bridge": "^4.0 || ^5.0",
-        "symfony/proxy-manager-bridge": "^4.0",
+        "symfony/framework-bundle": "^3.4 || ^4.0 || ^5.0",
+        "symfony/phpunit-bridge": "^3.4 || ^4.0 || ^5.0",
+        "symfony/proxy-manager-bridge": "*",
         "symfony/yaml": "^4.0 || ^5.0"
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -35,15 +35,16 @@
         "ext-json": "*",
         "doctrine/doctrine-bundle": "^1.8 || ^2.0",
         "doctrine/orm": "^2.5",
+        "friendsofphp/php-cs-fixer": "^2.15",
         "jms/serializer-bundle": "^3.0",
+        "laminas/laminas-zendframework-bridge": "^1.4",
         "ocramius/proxy-manager": "*",
         "phpunit/phpunit": "^8.5 || ^9.0",
+        "roave/security-advisories": "dev-master",
         "symfony/framework-bundle": "^4.0 || ^5.0",
         "symfony/phpunit-bridge": "^4.0 || ^5.0",
         "symfony/proxy-manager-bridge": "^4.0",
-        "symfony/yaml": "^4.0 || ^5.0",
-        "friendsofphp/php-cs-fixer": "^2.15",
-        "roave/security-advisories": "dev-master"
+        "symfony/yaml": "^4.0 || ^5.0"
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "friendsofphp/php-cs-fixer": "^2.15",
         "jms/serializer-bundle": "^3.0",
         "laminas/laminas-zendframework-bridge": "^1.4",
-        "ocramius/proxy-manager": "*",
+        "friendsofphp/proxy-manager-lts": "*",
         "phpunit/phpunit": "^8.5 || ^9.0",
         "roave/security-advisories": "dev-master",
         "symfony/framework-bundle": "^4.0 || ^5.0",

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "symfony/framework-bundle": "^3.4 || ^4.0 || ^5.0",
         "symfony/phpunit-bridge": "^3.4 || ^4.0 || ^5.0",
         "symfony/proxy-manager-bridge": "*",
-        "symfony/yaml": "^4.0 || ^5.0"
+        "symfony/yaml": "^3.4 || ^4.0 || ^5.0"
     },
     "extra": {
         "branch-alias": {

--- a/src/Command/IndexCommand.php
+++ b/src/Command/IndexCommand.php
@@ -31,8 +31,9 @@ abstract class IndexCommand extends Command
     {
         $entities   = [];
         $indexNames = [];
+        $indexList  = $input->getOption('indices');
 
-        if ($indexList = $input->getOption('indices')) {
+        if ((bool) $indexList) {
             $indexNames = explode(',', $indexList);
         }
 

--- a/src/Command/SearchImportCommand.php
+++ b/src/Command/SearchImportCommand.php
@@ -90,6 +90,7 @@ EOT
                 $this->searchClient->copyIndex($sourceIndexName, $temporaryIndexName, ['scope' => ['settings', 'synonyms', 'rules']]);
             }
 
+            $allResponses = [];
             foreach (is_subclass_of($entityClassName, Aggregator::class) ? $entityClassName::getEntities() : [$entityClassName] as $entityClass) {
                 $manager    = $this->managerRegistry->getManagerForClass($entityClass);
                 $repository = $manager->getRepository($entityClass);
@@ -103,7 +104,9 @@ EOT
                         $config['batchSize'] * $page
                     );
 
-                    $responses = $this->formatIndexingResponse($indexingService->index($manager, $entities));
+                    $response = $indexingService->index($manager, $entities);
+                    $allResponses[] = $response;
+                    $responses = $this->formatIndexingResponse($response);
 
                     foreach ($responses as $indexName => $numberOfRecords) {
                         $output->writeln(sprintf(
@@ -123,6 +126,10 @@ EOT
             }
 
             if ($shouldDoAtomicReindex && isset($indexName)) {
+                $output->writeln("Waiting for indexing tasks to finalize\n");
+                foreach ($allResponses as $response) {
+                    $response->wait();
+                }
                 $output->writeln("Moving <info>$indexName</info> -> <comment>$sourceIndexName</comment>\n");
                 $this->searchClient->moveIndex($indexName, $sourceIndexName);
             }

--- a/src/Command/SearchImportCommand.php
+++ b/src/Command/SearchImportCommand.php
@@ -104,9 +104,9 @@ EOT
                         $config['batchSize'] * $page
                     );
 
-                    $response = $indexingService->index($manager, $entities);
+                    $response       = $indexingService->index($manager, $entities);
                     $allResponses[] = $response;
-                    $responses = $this->formatIndexingResponse($response);
+                    $responses      = $this->formatIndexingResponse($response);
 
                     foreach ($responses as $indexName => $numberOfRecords) {
                         $output->writeln(sprintf(

--- a/src/Command/SearchImportCommand.php
+++ b/src/Command/SearchImportCommand.php
@@ -72,7 +72,7 @@ EOT
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $shouldDoAtomicReindex = $input->getOption('atomic');
+        $shouldDoAtomicReindex = (bool) $input->getOption('atomic');
         $entitiesToIndex       = $this->getEntitiesFromArgs($input, $output);
         $config                = $this->searchService->getConfiguration();
         $indexingService       = ($shouldDoAtomicReindex ? $this->searchServiceForAtomicReindex : $this->searchService);

--- a/src/Command/SearchSettingsCommand.php
+++ b/src/Command/SearchSettingsCommand.php
@@ -26,7 +26,9 @@ abstract class SearchSettingsCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        if ($indexList = $input->getOption('indices')) {
+        $indexList = $input->getOption('indices');
+
+        if ((bool) $indexList) {
             $indexList = explode(',', $indexList);
         }
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     

## Describe your change
This updates the `SearchImport` command to wait until all indexing operations are done before performing a `moveIndex` operation. This could prevent accidental loss of data.
