### PR TITLE
chore: migrate CircleCI image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
       - checkout
 
       - run: sudo apt-get update
-      - run: sudo apt-get install -y php<<parameters.version>>-zip libpq-dev php<<parameters.version>>-pgsql
+      - run: sudo apt-get install -y php<<parameters.version>>-zip libpq-dev php<<parameters.version>>-pgsql php<<parameters.version>>-mysql
 
       # Download and cache dependencies
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ executors:
         description: "PHP version tag"
         type: string
     docker:
-        - image: circleci/php:<<parameters.version>>
+        - image: cimg/php:<<parameters.version>>
 
 jobs:
   test:
@@ -27,8 +27,8 @@ jobs:
     steps:
       - checkout
 
-      - run: sudo apt update
-      - run: sudo docker-php-ext-install zip
+      - run: sudo apt-get update
+      - run: sudo apt-get install -y php<<parameters.version>>-zip
 
       # Download and cache dependencies
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
       - checkout
 
       - run: sudo apt-get update
-      - run: sudo apt-get install -y php<<parameters.version>>-zip libpq-dev php<<parameters.version>>-pgsql php<<parameters.version>>-mysql
+      - run: sudo apt-get install -y php<<parameters.version>>-zip php<<parameters.version>>-sqlite3
 
       # Download and cache dependencies
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
       - checkout
 
       - run: sudo apt-get update
-      - run: sudo apt-get install -y php<<parameters.version>>-zip
+      - run: sudo apt-get install -y php<<parameters.version>>-zip libpq-dev php<<parameters.version>>-pgsql
 
       # Download and cache dependencies
       - restore_cache:


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Need Doc update   | no

## Describe your change
This PR changes the Docker image used to run our tests. The current one in use will be deprecated by CircleCI.