### PR TITLE
feat: add support for symfony v6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,9 @@
         "algolia/algoliasearch-client-php": "^3.0",
         "doctrine/event-manager": "^1.1",
         "doctrine/persistence": "^2.1",
-        "symfony/filesystem": "^3.4 || ^4.0 || ^5.0",
-        "symfony/property-access": "^3.4 || ^4.0 || ^5.0",
-        "symfony/serializer": "^3.4 || ^4.0 || ^5.0"
+        "symfony/filesystem": "^3.4 || ^4.0 || ^5.0 || ^6.0",
+        "symfony/property-access": "^3.4 || ^4.0 || ^5.0 || ^6.0",
+        "symfony/serializer": "^3.4 || ^4.0 || ^5.0 || ^6.0"
     },
     "autoload": {
         "psr-4": {
@@ -40,10 +40,10 @@
         "friendsofphp/proxy-manager-lts": "*",
         "phpunit/phpunit": "^8.5 || ^9.0",
         "roave/security-advisories": "dev-master",
-        "symfony/framework-bundle": "^3.4 || ^4.0 || ^5.0",
-        "symfony/phpunit-bridge": "^3.4 || ^4.0 || ^5.0",
+        "symfony/framework-bundle": "^3.4 || ^4.0 || ^5.0 || ^6.0",
+        "symfony/phpunit-bridge": "^3.4 || ^4.0 || ^5.0 || ^6.0",
         "symfony/proxy-manager-bridge": "*",
-        "symfony/yaml": "^3.4 || ^4.0 || ^5.0"
+        "symfony/yaml": "^3.4 || ^4.0 || ^5.0 || ^6.0"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     

## Describe your change
This adds support for v6 of Symfony, which will [release](https://symfony.com/releases/6.0) in November 2021.
 