### PR TITLE
Update SettingsManager.php

### DIFF
--- a/src/Settings/SettingsManager.php
+++ b/src/Settings/SettingsManager.php
@@ -8,7 +8,7 @@ use Symfony\Component\Filesystem\Filesystem;
 /**
  * @internal
  */
-final class SettingsManager
+class SettingsManager
 {
     /**
      * @var SearchClient


### PR DESCRIPTION
Would allow us to implement our own SettingsManager that supports replicas. 

https://github.com/algolia/search-bundle/issues/348

| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no    
| BC breaks?        | no     
| Related Issue     | Fix #348  
| Need Doc update   | no


## Describe your change

Making class final removes the option for us to use DI to replace it with our own settings manager. 

Although the correct solution would be to implement interface and use that in DI, this will be braking change, while removing final shouldn't cause any issues and will make it extendible.

## What problem is this fixing?

Lack of extendability of settings manager service, which makes it impossible to reimplement it by devs to fix replica issue. 
