### PR TITLE
Replica settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 # Release Notes
 
 ## [Unreleased](https://github.com/algolia/search-bundle/compare/6.0.1...master)
+### Added
+- Automatically backup replicas settings
 
 ## [v6.0.1](https://github.com/algolia/search-bundle/compare/6.0.0...6.0.1)
 ### Changed

--- a/src/Settings/SettingsManager.php
+++ b/src/Settings/SettingsManager.php
@@ -45,16 +45,36 @@ class SettingsManager
         }
 
         foreach ($indices as $indexName) {
-            $index    = $this->algolia->initIndex($indexName);
-            $settings = $index->getSettings();
-            $filename = $this->getFileName($indexName, 'settings');
-
-            $fs->dumpFile($filename, json_encode($settings, JSON_PRETTY_PRINT));
-
-            $output[] = "Saved settings for <info>$indexName</info> in $filename";
+            $this->backupIndice($indexName, $fs, $output);
         }
 
         return $output;
+    }
+
+    private function backupIndice($indexName, $fs, &$output): void
+    {
+        $index    = $this->algolia->initIndex($indexName);
+        $settings = $index->getSettings();
+
+        // Handle replicas
+        if (array_key_exists('replicas', $settings)) {
+            foreach($settings['replicas'] as &$replica) {
+                // Backup replica settings
+                $this->backupIndice($replica, $fs, $output);
+
+                $replica = $this->removePrefixFromIndexName($replica);
+            }
+        }
+
+        if (array_key_exists('primary', $settings)) {
+            $settings['primary'] = $this->removePrefixFromIndexName($settings['primary']);
+        }
+
+        $filename = $this->getFileName($indexName, 'settings');
+
+        $fs->dumpFile($filename, json_encode($settings, JSON_PRETTY_PRINT));
+
+        $output[] = "Saved settings for <info>$indexName</info> in $filename";
     }
 
     /**


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no     
| Related Issue     | #348 & partially #269 
| Need Doc update   | no


## Describe your change

When we push / backup settings, replica will be detect and backup / push like other indices.
This feature, need replica to be create before that on Algolia with right name (prefix).

## What problem is this fixing?

Today, replicas can be handle only from Algolia administration and not sync between environments.