### PR TITLE
Add monolog.logger.algolia

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,7 @@
         "phpunit/phpunit": "^8.5 || ^9.0",
         "roave/security-advisories": "dev-master",
         "symfony/framework-bundle": "^7.0",
+        "symfony/monolog-bundle": "^3.10",
         "symfony/phpunit-bridge": "^7.0",
         "symfony/proxy-manager-bridge": "*",
         "symfony/yaml": "^7.0"

--- a/src/DependencyInjection/AlgoliaSearchExtension.php
+++ b/src/DependencyInjection/AlgoliaSearchExtension.php
@@ -7,6 +7,7 @@ use Algolia\SearchBundle\Services\AlgoliaSearchService;
 use Algolia\SearchBundle\Settings\SettingsManager;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\DependencyInjection\Reference;
@@ -70,8 +71,10 @@ final class AlgoliaSearchExtension extends Extension
                 new Reference($config['serializer']),
                 $engineDefinition,
                 $config,
+                new Reference('logger', ContainerInterface::IGNORE_ON_INVALID_REFERENCE),
             ]
         ));
+        $searchServiceDefinition->addTag('monolog.logger', ['channel' => 'algolia']);
 
         $searchServiceDefinitionForAtomicReindex = (clone $searchServiceDefinition);
         $searchServiceDefinitionForAtomicReindex->replaceArgument(

--- a/src/Services/AlgoliaSearchService.php
+++ b/src/Services/AlgoliaSearchService.php
@@ -2,6 +2,7 @@
 
 namespace Algolia\SearchBundle\Services;
 
+use Algolia\AlgoliaSearch\Algolia;
 use Algolia\AlgoliaSearch\RequestOptions\RequestOptions;
 use Algolia\SearchBundle\Engine;
 use Algolia\SearchBundle\Entity\Aggregator;
@@ -10,6 +11,8 @@ use Algolia\SearchBundle\SearchableEntity;
 use Algolia\SearchBundle\SearchService;
 use Algolia\SearchBundle\Util\ClassInfo;
 use Doctrine\Persistence\ObjectManager;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Symfony\Component\Config\Definition\Exception\Exception;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 
@@ -62,15 +65,19 @@ final class AlgoliaSearchService implements SearchService
 
     private $normalizer;
 
+    private LoggerInterface $logger;
+
     /**
      * @param array<string, array|int|string> $configuration
      */
-    public function __construct($normalizer, Engine $engine, array $configuration)
+    public function __construct($normalizer, Engine $engine, array $configuration, ?LoggerInterface $logger = null)
     {
         $this->normalizer       = $normalizer;
         $this->engine           = $engine;
         $this->configuration    = $configuration;
         $this->propertyAccessor = PropertyAccess::createPropertyAccessor();
+        $this->logger           = $logger ?? new NullLogger();
+        Algolia::setLogger($this->logger);
 
         $this->setSearchableEntities();
         $this->setAggregatorsAndEntitiesAggregators();

--- a/tests/Kernel.php
+++ b/tests/Kernel.php
@@ -19,6 +19,7 @@ class Kernel extends HttpKernel
             new \Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
             new \Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
             new \JMS\SerializerBundle\JMSSerializerBundle(),
+            new \Symfony\Bundle\MonologBundle\MonologBundle(),
             new AlgoliaSearchBundle(),
         ];
     }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | n/c
| Need Doc update   | no


## Describe your change

Hello, I would like to propose adding logging capabilities since it is already supported by `algolia/algoliasearch-client-php`.

This is logging to a dedicated monolog channel named `algolia`.

Ps: I would prefer to use DI but the `Algolia\AlgoliaSearch\RetryStrategy\ApiWrapper` is instanciated from `Algolia\AlgoliaSearch\SearchClient::createWithConfig()` which does not allow to inject a logger, and belongs to `algolia/algoliasearch-client-php`. So I went the most straightforward way.

## What problem is this fixing?

Nothing gets logged when sending requests to algolia, which is an issue when trying to debug something with the search engine. The good part is that  `algolia/algoliasearch-client-php` already logs useful information, it just don't use any logger right now.
