### PR TITLE
Ensure the transaction has succeeded before indexing or removing objects

### DIFF
--- a/src/EventListener/SearchIndexerSubscriber.php
+++ b/src/EventListener/SearchIndexerSubscriber.php
@@ -10,11 +10,11 @@ use Doctrine\ORM\Event\PreRemoveEventArgs;
 
 class SearchIndexerSubscriber
 {
-    private array $objectsToIndex = [];
+    private array $objectsToIndex  = [];
     private array $objectsToRemove = [];
 
     public function __construct(
-        private readonly SearchService $searchService
+        private readonly SearchService $searchService,
     ) {
     }
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | none
| Need Doc update   | no


## Describe your change

Index and remove objects during the `postFlush` event to ensure the transaction has succeeded.

## What problem is this fixing?

The `postUpdate` and `postPersist` events are triggered after the database operations on entity data **but before the transaction has been committed**. 
https://www.doctrine-project.org/projects/doctrine-orm/en/3.3/reference/events.html#postupdate-postremove-postpersist

If the transaction fails, the object could be indexed in Algolia without the corresponding database change, causing desynchronization between the database and Algolia. By indexing or removing objects in the `postFlush` event, we ensure that the transaction has succeeded first.