### PR TITLE
Restore Symfony 6.4 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,9 @@
         "algolia/algoliasearch-client-php": "^3.0",
         "doctrine/event-manager": "^1.1 || ^2.0",
         "doctrine/persistence": "^2.1 || ^3.0",
-        "symfony/filesystem": "^7.0",
-        "symfony/property-access": "^7.0",
-        "symfony/serializer": "^7.0"
+        "symfony/filesystem": "^6.4 || ^7.0",
+        "symfony/property-access": "^6.4 || ^7.0",
+        "symfony/serializer": "^6.4 || ^7.0"
     },
     "autoload": {
         "psr-4": {
@@ -40,14 +40,14 @@
         "friendsofphp/proxy-manager-lts": "*",
         "phpunit/phpunit": "^8.5 || ^9.0",
         "roave/security-advisories": "dev-master",
-        "symfony/framework-bundle": "^7.0",
-        "symfony/phpunit-bridge": "^7.0",
+        "symfony/framework-bundle": "^6.4 || ^7.0",
+        "symfony/phpunit-bridge": "^6.4 || ^7.0",
         "symfony/proxy-manager-bridge": "*",
-        "symfony/yaml": "^7.0"
+        "symfony/yaml": "^6.4 || ^7.0"
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.x-dev"
+            "dev-master": "7.x-dev"
         }
     },
     "config": {


### PR DESCRIPTION


| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no     
| Related Issue     |
| Need Doc update   | yes


## Describe your change

Restore compatibility with Symfony 6.4.

## What problem is this fixing?

The reasons for restore 6.4:
- 6.4 & 7.0 are equivalent (except for deprecations removed)
- Will ease upgrade of project from sf 6.4 to 7.0. This bundle will be upgradable on its own, without doing both it and sf upgrade at the same time. (that the main reason :wink: )

## Update doc

Need to change Symfony version on:
https://www.algolia.com/doc/framework-integration/symfony/getting-started/algolia-searchbundle/?client=php