### PR TITLE
fix(config): initialize the serializer for custom_normalizer

### DIFF
--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -41,6 +41,9 @@
         <!-- CustomNormalizer is not registered by framework-bundle -->
         <service id="custom_normalizer" class="Symfony\Component\Serializer\Normalizer\CustomNormalizer" public="false">
             <tag name="serializer.normalizer" priority="-800" />
+            <call method="setSerializer">
+                <argument type="service" id="serializer" />
+            </call>
         </service>
 
     </services>


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no 
| BC breaks?        | no     
| Need Doc update   | no

This add a call to `CustomNormalizer::setSerialize()` passing it the serializer service which is used by the normalize and denormalize methods and is currently null as this initilization is not done in Symfony's CustomNormalizer construct



