### PR TITLE
fix: add index cleanup cron

### DIFF
--- a/.github/scripts/cleanup-test-indexes.js
+++ b/.github/scripts/cleanup-test-indexes.js
@@ -1,0 +1,45 @@
+const { algoliasearch } = require('algoliasearch');
+
+const BATCH_SIZE = 20;
+
+async function main() {
+  const client = algoliasearch(process.env.APP_ID, process.env.API_KEY);
+
+  const { items } = await client.listIndices();
+  const names = items.map((i) => i.name).filter((n) => n.includes('sf_phpunit_'));
+
+  if (names.length === 0) {
+    console.log('Nothing to delete.');
+    return;
+  }
+
+  console.log(`Deleting ${names.length} indexes in batches of ${BATCH_SIZE}...`);
+
+  const tasks = [];
+  for (let i = 0; i < names.length; i += BATCH_SIZE) {
+    const batch = names.slice(i, i + BATCH_SIZE);
+    const batchTasks = await Promise.all(
+      batch.map(async (name) => {
+        const { taskID } = await client.deleteIndex({ indexName: name });
+        return { name, taskID };
+      })
+    );
+    tasks.push(...batchTasks);
+    console.log(`  requested ${Math.min(i + BATCH_SIZE, names.length)}/${names.length}`);
+  }
+
+  console.log('Waiting for all tasks to complete...');
+  await Promise.all(
+    tasks.map(async ({ name, taskID }) => {
+      await client.waitForTask({ indexName: name, taskID });
+      console.log(`  confirmed ${name}`);
+    })
+  );
+
+  console.log('All deletes confirmed.');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/.github/scripts/package.json
+++ b/.github/scripts/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "search-bundle-ci-scripts",
+  "private": true,
+  "dependencies": {
+    "algoliasearch": "^5"
+  },
+  "devDependencies": {
+    "@types/node": "^24"
+  }
+}

--- a/.github/workflows/cleanup-test-indexes.yml
+++ b/.github/workflows/cleanup-test-indexes.yml
@@ -12,7 +12,7 @@ jobs:
       APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
       API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
     steps:
-      - name: Delete sf_phpunit_* indexes
+      - name: Delete sf_phpunit_* indexes (including atomic-reindex temps)
         run: |
           set -euo pipefail
 
@@ -20,7 +20,7 @@ jobs:
           host="https://${APP_ID}.algolia.net"
 
           names=$(curl -sSf "${auth[@]}" "$host/1/indexes" \
-            | jq -r '.items[].name | select(startswith("sf_phpunit_"))')
+            | jq -r '.items[].name | select(contains("sf_phpunit_"))')
 
           if [ -z "$names" ]; then
             echo "Nothing to delete."

--- a/.github/workflows/cleanup-test-indexes.yml
+++ b/.github/workflows/cleanup-test-indexes.yml
@@ -8,28 +8,14 @@ on:
 jobs:
   cleanup:
     runs-on: ubuntu-latest
-    env:
-      APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
-      API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
     steps:
-      - name: Delete sf_phpunit_* indexes (including atomic-reindex temps)
-        run: |
-          set -euo pipefail
-
-          auth=(-H "X-Algolia-Application-Id: $APP_ID" -H "X-Algolia-API-Key: $API_KEY")
-          host="https://${APP_ID}.algolia.net"
-
-          names=$(curl -sSf "${auth[@]}" "$host/1/indexes" \
-            | jq -r '.items[].name | select(contains("sf_phpunit_"))')
-
-          if [ -z "$names" ]; then
-            echo "Nothing to delete."
-            exit 0
-          fi
-
-          echo "Deleting $(echo "$names" | wc -l) indexes..."
-          while IFS= read -r name; do
-            encoded=$(jq -rn --arg v "$name" '$v|@uri')
-            curl -sSf -X DELETE "${auth[@]}" "$host/1/indexes/$encoded" > /dev/null
-            echo "  $name"
-          done <<< "$names"
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - run: npm install algoliasearch@^5 --no-save
+      - name: Delete sf_phpunit_* indexes
+        env:
+          APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
+          API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
+        run: node .github/scripts/cleanup-test-indexes.js

--- a/.github/workflows/cleanup-test-indexes.yml
+++ b/.github/workflows/cleanup-test-indexes.yml
@@ -1,0 +1,35 @@
+name: Cleanup test indexes
+
+on:
+  schedule:
+    - cron: '0 3 * * 0'
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    env:
+      APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
+      API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
+    steps:
+      - name: Delete sf_phpunit_* indexes
+        run: |
+          set -euo pipefail
+
+          auth=(-H "X-Algolia-Application-Id: $APP_ID" -H "X-Algolia-API-Key: $API_KEY")
+          host="https://${APP_ID}.algolia.net"
+
+          names=$(curl -sSf "${auth[@]}" "$host/1/indexes" \
+            | jq -r '.items[].name | select(startswith("sf_phpunit_"))')
+
+          if [ -z "$names" ]; then
+            echo "Nothing to delete."
+            exit 0
+          fi
+
+          echo "Deleting $(echo "$names" | wc -l) indexes..."
+          while IFS= read -r name; do
+            encoded=$(jq -rn --arg v "$name" '$v|@uri')
+            curl -sSf -X DELETE "${auth[@]}" "$host/1/indexes/$encoded" > /dev/null
+            echo "  $name"
+          done <<< "$names"

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ clover.xml
 /tests/QualityTools/composer.lock
 .phpunit.result.cache
 phpunit.xml.dist.bak
+/.github/scripts/node_modules/
+/.github/scripts/package-lock.json


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Need Doc update   | no


## Describe your change
Adds .github/workflows/cleanup-test-indexes.yml: a weekly cron (Sundays 03:00 UTC, also workflow_dispatch) that deletes every Algolia index prefixed with sf_phpunit_ using the existing CI secrets.

## What problem is this fixing?
Test indexes leak forever. The prefix bakes in GITHUB_RUN_NUMBER, so every CI run creates a fresh set of ~30 unique indexes and nothing ever deletes them.
